### PR TITLE
[#17][#26] iOS project init with native OAuth (no Amplify)

### DIFF
--- a/ios/TimelessApp/TimelessApp.xcodeproj/project.pbxproj
+++ b/ios/TimelessApp/TimelessApp.xcodeproj/project.pbxproj
@@ -1,0 +1,462 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 56;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		B1000001230001 /* TimelessApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1000001130001 /* TimelessApp.swift */; };
+		B1000001230002 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1000001130002 /* ContentView.swift */; };
+		B1000001230003 /* Colors.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1000001130003 /* Colors.swift */; };
+		B1000001230004 /* Gradients.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1000001130004 /* Gradients.swift */; };
+		B1000001230005 /* Typography.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1000001130005 /* Typography.swift */; };
+		B1000001230006 /* Spacing.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1000001130006 /* Spacing.swift */; };
+		B1000001230007 /* PrimaryButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1000001130007 /* PrimaryButton.swift */; };
+		B1000001230008 /* LoginView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1000001130008 /* LoginView.swift */; };
+		B1000001230009 /* LoginViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1000001130009 /* LoginViewModel.swift */; };
+		B1000001230010 /* AuthService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1000001130010 /* AuthService.swift */; };
+		B1000001230011 /* KeychainService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1000001130011 /* KeychainService.swift */; };
+		B1000001230012 /* CognitoConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1000001130012 /* CognitoConfig.swift */; };
+		B1000001230013 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = B1000001130013 /* Assets.xcassets */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		B1000001110001 /* TimelessApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = TimelessApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		B1000001130001 /* TimelessApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimelessApp.swift; sourceTree = "<group>"; };
+		B1000001130002 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+		B1000001130003 /* Colors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Colors.swift; sourceTree = "<group>"; };
+		B1000001130004 /* Gradients.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Gradients.swift; sourceTree = "<group>"; };
+		B1000001130005 /* Typography.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Typography.swift; sourceTree = "<group>"; };
+		B1000001130006 /* Spacing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Spacing.swift; sourceTree = "<group>"; };
+		B1000001130007 /* PrimaryButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrimaryButton.swift; sourceTree = "<group>"; };
+		B1000001130008 /* LoginView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginView.swift; sourceTree = "<group>"; };
+		B1000001130009 /* LoginViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginViewModel.swift; sourceTree = "<group>"; };
+		B1000001130010 /* AuthService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthService.swift; sourceTree = "<group>"; };
+		B1000001130011 /* KeychainService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainService.swift; sourceTree = "<group>"; };
+		B1000001130012 /* CognitoConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CognitoConfig.swift; sourceTree = "<group>"; };
+		B1000001130013 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		B1000001130014 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		B1000001200001 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		B1000001010001 = {
+			isa = PBXGroup;
+			children = (
+				B1000001020001 /* TimelessApp */,
+				B1000001030001 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		B1000001020001 /* TimelessApp */ = {
+			isa = PBXGroup;
+			children = (
+				B1000001040001 /* App */,
+				B1000001040002 /* DesignSystem */,
+				B1000001040003 /* Models */,
+				B1000001040004 /* ViewModels */,
+				B1000001040005 /* Views */,
+				B1000001040006 /* Utilities */,
+				B1000001040007 /* Resources */,
+				B1000001130014 /* Info.plist */,
+			);
+			path = TimelessApp;
+			sourceTree = "<group>";
+		};
+		B1000001030001 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				B1000001110001 /* TimelessApp.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		B1000001040001 /* App */ = {
+			isa = PBXGroup;
+			children = (
+				B1000001130001 /* TimelessApp.swift */,
+				B1000001130002 /* ContentView.swift */,
+			);
+			path = App;
+			sourceTree = "<group>";
+		};
+		B1000001040002 /* DesignSystem */ = {
+			isa = PBXGroup;
+			children = (
+				B1000001050001 /* Tokens */,
+				B1000001050002 /* Components */,
+			);
+			path = DesignSystem;
+			sourceTree = "<group>";
+		};
+		B1000001050001 /* Tokens */ = {
+			isa = PBXGroup;
+			children = (
+				B1000001130003 /* Colors.swift */,
+				B1000001130004 /* Gradients.swift */,
+				B1000001130005 /* Typography.swift */,
+				B1000001130006 /* Spacing.swift */,
+			);
+			path = Tokens;
+			sourceTree = "<group>";
+		};
+		B1000001050002 /* Components */ = {
+			isa = PBXGroup;
+			children = (
+				B1000001130007 /* PrimaryButton.swift */,
+			);
+			path = Components;
+			sourceTree = "<group>";
+		};
+		B1000001040003 /* Models */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = Models;
+			sourceTree = "<group>";
+		};
+		B1000001040004 /* ViewModels */ = {
+			isa = PBXGroup;
+			children = (
+				B1000001130009 /* LoginViewModel.swift */,
+			);
+			path = ViewModels;
+			sourceTree = "<group>";
+		};
+		B1000001040005 /* Views */ = {
+			isa = PBXGroup;
+			children = (
+				B1000001060001 /* Login */,
+			);
+			path = Views;
+			sourceTree = "<group>";
+		};
+		B1000001060001 /* Login */ = {
+			isa = PBXGroup;
+			children = (
+				B1000001130008 /* LoginView.swift */,
+			);
+			path = Login;
+			sourceTree = "<group>";
+		};
+		B1000001040006 /* Utilities */ = {
+			isa = PBXGroup;
+			children = (
+				B1000001130010 /* AuthService.swift */,
+				B1000001130011 /* KeychainService.swift */,
+				B1000001130012 /* CognitoConfig.swift */,
+			);
+			path = Utilities;
+			sourceTree = "<group>";
+		};
+		B1000001040007 /* Resources */ = {
+			isa = PBXGroup;
+			children = (
+				B1000001130013 /* Assets.xcassets */,
+			);
+			path = Resources;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		B1000001100001 /* TimelessApp */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = B1000001300001 /* Build configuration list for PBXNativeTarget "TimelessApp" */;
+			buildPhases = (
+				B1000001210001 /* Sources */,
+				B1000001200001 /* Frameworks */,
+				B1000001220001 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = TimelessApp;
+			productName = TimelessApp;
+			productReference = B1000001110001 /* TimelessApp.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		B1000001000001 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 1500;
+				LastUpgradeCheck = 1500;
+				TargetAttributes = {
+					B1000001100001 = {
+						CreatedOnToolsVersion = 15.0;
+					};
+				};
+			};
+			buildConfigurationList = B1000001300002 /* Build configuration list for PBXProject "TimelessApp" */;
+			compatibilityVersion = "Xcode 14.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+				"zh-Hant",
+				"zh-Hans",
+				ja,
+				ko,
+			);
+			mainGroup = B1000001010001;
+			productRefGroup = B1000001030001 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				B1000001100001 /* TimelessApp */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		B1000001220001 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				B1000001230013 /* Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		B1000001210001 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				B1000001230001 /* TimelessApp.swift in Sources */,
+				B1000001230002 /* ContentView.swift in Sources */,
+				B1000001230003 /* Colors.swift in Sources */,
+				B1000001230004 /* Gradients.swift in Sources */,
+				B1000001230005 /* Typography.swift in Sources */,
+				B1000001230006 /* Spacing.swift in Sources */,
+				B1000001230007 /* PrimaryButton.swift in Sources */,
+				B1000001230008 /* LoginView.swift in Sources */,
+				B1000001230009 /* LoginViewModel.swift in Sources */,
+				B1000001230010 /* AuthService.swift in Sources */,
+				B1000001230011 /* KeychainService.swift in Sources */,
+				B1000001230012 /* CognitoConfig.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		B1000001310001 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = "";
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = TimelessApp/Info.plist;
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.timeless.app;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		B1000001310002 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = "";
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = TimelessApp/Info.plist;
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.timeless.app;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+		B1000001320001 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		B1000001320002 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		B1000001300001 /* Build configuration list for PBXNativeTarget "TimelessApp" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				B1000001310001 /* Debug */,
+				B1000001310002 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		B1000001300002 /* Build configuration list for PBXProject "TimelessApp" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				B1000001320001 /* Debug */,
+				B1000001320002 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+
+	};
+	rootObject = B1000001000001 /* Project object */;
+}

--- a/ios/TimelessApp/TimelessApp/App/ContentView.swift
+++ b/ios/TimelessApp/TimelessApp/App/ContentView.swift
@@ -1,0 +1,11 @@
+import SwiftUI
+
+struct ContentView: View {
+    var body: some View {
+        LoginView()
+    }
+}
+
+#Preview {
+    ContentView()
+}

--- a/ios/TimelessApp/TimelessApp/App/TimelessApp.swift
+++ b/ios/TimelessApp/TimelessApp/App/TimelessApp.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+
+@main
+struct TimelessApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}

--- a/ios/TimelessApp/TimelessApp/DesignSystem/Components/PrimaryButton.swift
+++ b/ios/TimelessApp/TimelessApp/DesignSystem/Components/PrimaryButton.swift
@@ -1,0 +1,85 @@
+import SwiftUI
+
+/// Primary button with gradient background
+struct PrimaryButton: View {
+    let title: String
+    let icon: String?
+    let action: () -> Void
+
+    init(
+        _ title: String,
+        icon: String? = nil,
+        action: @escaping () -> Void
+    ) {
+        self.title = title
+        self.icon = icon
+        self.action = action
+    }
+
+    var body: some View {
+        Button(action: action) {
+            HStack(spacing: Spacing.xs) {
+                if let icon = icon {
+                    Image(systemName: icon)
+                        .font(.titleMedium)
+                }
+                Text(title)
+                    .font(.titleMedium)
+            }
+            .foregroundColor(.textPrimary)
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, Spacing.md)
+            .background(LinearGradient.button)
+            .cornerRadius(CornerRadius.lg)
+        }
+        .buttonStyle(.plain)
+    }
+}
+
+/// Secondary outline button
+struct SecondaryButton: View {
+    let title: String
+    let icon: String?
+    let action: () -> Void
+
+    init(
+        _ title: String,
+        icon: String? = nil,
+        action: @escaping () -> Void
+    ) {
+        self.title = title
+        self.icon = icon
+        self.action = action
+    }
+
+    var body: some View {
+        Button(action: action) {
+            HStack(spacing: Spacing.xs) {
+                if let icon = icon {
+                    Image(systemName: icon)
+                        .font(.titleMedium)
+                }
+                Text(title)
+                    .font(.titleMedium)
+            }
+            .foregroundColor(.primary500)
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, Spacing.md)
+            .background(Color.clear)
+            .overlay(
+                RoundedRectangle(cornerRadius: CornerRadius.lg)
+                    .stroke(Color.primary500, lineWidth: 1.5)
+            )
+        }
+        .buttonStyle(.plain)
+    }
+}
+
+#Preview {
+    VStack(spacing: Spacing.md) {
+        PrimaryButton("Sign in with Google", icon: "person.fill") {}
+        SecondaryButton("Continue with Email", icon: "envelope.fill") {}
+    }
+    .padding()
+    .background(Color.backgroundDark)
+}

--- a/ios/TimelessApp/TimelessApp/DesignSystem/Tokens/Colors.swift
+++ b/ios/TimelessApp/TimelessApp/DesignSystem/Tokens/Colors.swift
@@ -1,0 +1,78 @@
+import SwiftUI
+
+/// Timeless Design System Colors
+/// Tech Neon (科技霓虹風格)
+extension Color {
+    // MARK: - Primary (科技紫)
+    static let primary50 = Color(hex: "#f5f3ff")
+    static let primary100 = Color(hex: "#ede9fe")
+    static let primary200 = Color(hex: "#ddd6fe")
+    static let primary300 = Color(hex: "#c4b5fd")
+    static let primary400 = Color(hex: "#a78bfa")
+    static let primary500 = Color(hex: "#8b5cf6") // ⭐ Main
+    static let primary600 = Color(hex: "#7c3aed")
+    static let primary700 = Color(hex: "#6d28d9")
+    static let primary800 = Color(hex: "#5b21b6")
+    static let primary900 = Color(hex: "#4c1d95")
+
+    // MARK: - Accent (霓虹粉紫)
+    static let accent50 = Color(hex: "#fdf4ff")
+    static let accent100 = Color(hex: "#fae8ff")
+    static let accent200 = Color(hex: "#f5d0fe")
+    static let accent300 = Color(hex: "#f0abfc")
+    static let accent400 = Color(hex: "#e879f9") // ⭐ Main
+    static let accent500 = Color(hex: "#d946ef")
+    static let accent600 = Color(hex: "#c026d3")
+    static let accent700 = Color(hex: "#a21caf")
+
+    // MARK: - Secondary (科技青)
+    static let secondary50 = Color(hex: "#ecfeff")
+    static let secondary100 = Color(hex: "#cffafe")
+    static let secondary200 = Color(hex: "#a5f3fc")
+    static let secondary300 = Color(hex: "#67e8f9")
+    static let secondary400 = Color(hex: "#22d3ee") // ⭐ Main
+    static let secondary500 = Color(hex: "#06b6d4")
+    static let secondary600 = Color(hex: "#0891b2")
+
+    // MARK: - Background
+    static let backgroundDark = Color(hex: "#0a0a0f")
+    static let backgroundCard = Color(hex: "#12121a")
+    static let backgroundElevated = Color(hex: "#1a1a24")
+
+    // MARK: - Surface
+    static let surface = Color(hex: "#18181b")
+    static let surfaceHover = Color(hex: "#27272a")
+    static let surfaceBorder = Color(hex: "#3f3f46")
+
+    // MARK: - Text
+    static let textPrimary = Color(hex: "#fafafa")
+    static let textSecondary = Color(hex: "#a1a1aa")
+    static let textMuted = Color(hex: "#71717a")
+}
+
+// MARK: - Hex Color Extension
+extension Color {
+    init(hex: String) {
+        let hex = hex.trimmingCharacters(in: CharacterSet.alphanumerics.inverted)
+        var int: UInt64 = 0
+        Scanner(string: hex).scanHexInt64(&int)
+        let a, r, g, b: UInt64
+        switch hex.count {
+        case 3: // RGB (12-bit)
+            (a, r, g, b) = (255, (int >> 8) * 17, (int >> 4 & 0xF) * 17, (int & 0xF) * 17)
+        case 6: // RGB (24-bit)
+            (a, r, g, b) = (255, int >> 16, int >> 8 & 0xFF, int & 0xFF)
+        case 8: // ARGB (32-bit)
+            (a, r, g, b) = (int >> 24, int >> 16 & 0xFF, int >> 8 & 0xFF, int & 0xFF)
+        default:
+            (a, r, g, b) = (1, 1, 1, 0)
+        }
+        self.init(
+            .sRGB,
+            red: Double(r) / 255,
+            green: Double(g) / 255,
+            blue: Double(b) / 255,
+            opacity: Double(a) / 255
+        )
+    }
+}

--- a/ios/TimelessApp/TimelessApp/DesignSystem/Tokens/Gradients.swift
+++ b/ios/TimelessApp/TimelessApp/DesignSystem/Tokens/Gradients.swift
@@ -1,0 +1,32 @@
+import SwiftUI
+
+/// Timeless Design System Gradients
+extension LinearGradient {
+    /// Primary gradient - 科技紫漸層
+    static let primary = LinearGradient(
+        colors: [.primary500, .accent400],
+        startPoint: .topLeading,
+        endPoint: .bottomTrailing
+    )
+
+    /// Neon glow gradient
+    static let neonGlow = LinearGradient(
+        colors: [.primary400, .accent400, .secondary400],
+        startPoint: .leading,
+        endPoint: .trailing
+    )
+
+    /// Card background gradient
+    static let cardBackground = LinearGradient(
+        colors: [.backgroundCard, .backgroundElevated],
+        startPoint: .top,
+        endPoint: .bottom
+    )
+
+    /// Button gradient
+    static let button = LinearGradient(
+        colors: [.primary500, .primary600],
+        startPoint: .top,
+        endPoint: .bottom
+    )
+}

--- a/ios/TimelessApp/TimelessApp/DesignSystem/Tokens/Spacing.swift
+++ b/ios/TimelessApp/TimelessApp/DesignSystem/Tokens/Spacing.swift
@@ -1,0 +1,23 @@
+import SwiftUI
+
+/// Timeless Design System Spacing
+enum Spacing {
+    static let xxxs: CGFloat = 2
+    static let xxs: CGFloat = 4
+    static let xs: CGFloat = 8
+    static let sm: CGFloat = 12
+    static let md: CGFloat = 16
+    static let lg: CGFloat = 24
+    static let xl: CGFloat = 32
+    static let xxl: CGFloat = 48
+    static let xxxl: CGFloat = 64
+}
+
+/// Corner Radius
+enum CornerRadius {
+    static let sm: CGFloat = 8
+    static let md: CGFloat = 12
+    static let lg: CGFloat = 16
+    static let xl: CGFloat = 24
+    static let full: CGFloat = 9999
+}

--- a/ios/TimelessApp/TimelessApp/DesignSystem/Tokens/Typography.swift
+++ b/ios/TimelessApp/TimelessApp/DesignSystem/Tokens/Typography.swift
@@ -1,0 +1,29 @@
+import SwiftUI
+
+/// Timeless Design System Typography
+extension Font {
+    // MARK: - Display
+    static let displayLarge = Font.system(size: 57, weight: .bold)
+    static let displayMedium = Font.system(size: 45, weight: .bold)
+    static let displaySmall = Font.system(size: 36, weight: .bold)
+
+    // MARK: - Headline
+    static let headlineLarge = Font.system(size: 32, weight: .semibold)
+    static let headlineMedium = Font.system(size: 28, weight: .semibold)
+    static let headlineSmall = Font.system(size: 24, weight: .semibold)
+
+    // MARK: - Title
+    static let titleLarge = Font.system(size: 22, weight: .medium)
+    static let titleMedium = Font.system(size: 16, weight: .medium)
+    static let titleSmall = Font.system(size: 14, weight: .medium)
+
+    // MARK: - Body
+    static let bodyLarge = Font.system(size: 16, weight: .regular)
+    static let bodyMedium = Font.system(size: 14, weight: .regular)
+    static let bodySmall = Font.system(size: 12, weight: .regular)
+
+    // MARK: - Label
+    static let labelLarge = Font.system(size: 14, weight: .medium)
+    static let labelMedium = Font.system(size: 12, weight: .medium)
+    static let labelSmall = Font.system(size: 11, weight: .medium)
+}

--- a/ios/TimelessApp/TimelessApp/Info.plist
+++ b/ios/TimelessApp/TimelessApp/Info.plist
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleURLTypes</key>
+    <array>
+        <dict>
+            <key>CFBundleTypeRole</key>
+            <string>Editor</string>
+            <key>CFBundleURLName</key>
+            <string>com.timeless.app</string>
+            <key>CFBundleURLSchemes</key>
+            <array>
+                <string>timeless</string>
+            </array>
+        </dict>
+    </array>
+    <key>LSApplicationQueriesSchemes</key>
+    <array>
+        <string>https</string>
+    </array>
+    <key>NSFaceIDUsageDescription</key>
+    <string>Use Face ID to securely sign in to Timeless</string>
+</dict>
+</plist>

--- a/ios/TimelessApp/TimelessApp/Resources/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/ios/TimelessApp/TimelessApp/Resources/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.965",
+          "green" : "0.361",
+          "red" : "0.545"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ios/TimelessApp/TimelessApp/Resources/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/ios/TimelessApp/TimelessApp/Resources/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,13 @@
+{
+  "images" : [
+    {
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ios/TimelessApp/TimelessApp/Resources/Assets.xcassets/Contents.json
+++ b/ios/TimelessApp/TimelessApp/Resources/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ios/TimelessApp/TimelessApp/Utilities/AuthService.swift
+++ b/ios/TimelessApp/TimelessApp/Utilities/AuthService.swift
@@ -1,0 +1,215 @@
+import AuthenticationServices
+import Foundation
+
+/// Authentication service using native OAuth
+/// Uses ASWebAuthenticationSession for Cognito Hosted UI
+actor AuthService {
+    static let shared = AuthService()
+
+    private let config = CognitoConfig.shared
+    private let keychain = KeychainService.shared
+
+    private init() {}
+
+    // MARK: - Google Sign In via Cognito Hosted UI
+
+    @MainActor
+    func signInWithGoogle() async throws {
+        let authURL = buildAuthURL(identityProvider: "Google")
+        let callbackScheme = config.callbackURLScheme
+
+        let url = try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<URL, Error>) in
+            let session = ASWebAuthenticationSession(
+                url: authURL,
+                callbackURLScheme: callbackScheme
+            ) { callbackURL, error in
+                if let error = error {
+                    continuation.resume(throwing: error)
+                } else if let callbackURL = callbackURL {
+                    continuation.resume(returning: callbackURL)
+                } else {
+                    continuation.resume(throwing: AuthError.unknownError)
+                }
+            }
+
+            session.presentationContextProvider = ASWebAuthenticationPresentationContextProvider.shared
+            session.prefersEphemeralWebBrowserSession = false
+
+            if !session.start() {
+                continuation.resume(throwing: AuthError.failedToStartSession)
+            }
+        }
+
+        // Exchange authorization code for tokens
+        let tokens = try await exchangeCodeForTokens(callbackURL: url)
+        try await keychain.saveTokens(tokens)
+    }
+
+    // MARK: - Apple Sign In
+
+    @MainActor
+    func signInWithApple() async throws {
+        // Apple Sign In implementation
+        // Uses ASAuthorizationController
+        throw AuthError.notImplemented
+    }
+
+    // MARK: - Token Management
+
+    func getAccessToken() async throws -> String {
+        guard let tokens = try await keychain.getTokens() else {
+            throw AuthError.notAuthenticated
+        }
+
+        // Check if access token is expired
+        if tokens.isAccessTokenExpired {
+            let newTokens = try await refreshTokens(refreshToken: tokens.refreshToken)
+            try await keychain.saveTokens(newTokens)
+            return newTokens.accessToken
+        }
+
+        return tokens.accessToken
+    }
+
+    func signOut() async throws {
+        try await keychain.deleteTokens()
+    }
+
+    // MARK: - Private Methods
+
+    private func buildAuthURL(identityProvider: String) -> URL {
+        var components = URLComponents()
+        components.scheme = "https"
+        components.host = config.domain
+        components.path = "/oauth2/authorize"
+        components.queryItems = [
+            URLQueryItem(name: "client_id", value: config.clientId),
+            URLQueryItem(name: "response_type", value: "code"),
+            URLQueryItem(name: "scope", value: "openid email profile"),
+            URLQueryItem(name: "redirect_uri", value: config.callbackURL),
+            URLQueryItem(name: "identity_provider", value: identityProvider)
+        ]
+        return components.url!
+    }
+
+    private func exchangeCodeForTokens(callbackURL: URL) async throws -> AuthTokens {
+        // Parse authorization code from callback URL
+        guard let components = URLComponents(url: callbackURL, resolvingAgainstBaseURL: false),
+              let code = components.queryItems?.first(where: { $0.name == "code" })?.value else {
+            throw AuthError.invalidCallback
+        }
+
+        // Exchange code for tokens
+        var request = URLRequest(url: URL(string: "https://\(config.domain)/oauth2/token")!)
+        request.httpMethod = "POST"
+        request.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
+
+        let body = [
+            "grant_type": "authorization_code",
+            "client_id": config.clientId,
+            "code": code,
+            "redirect_uri": config.callbackURL
+        ]
+        request.httpBody = body.map { "\($0.key)=\($0.value)" }.joined(separator: "&").data(using: .utf8)
+
+        let (data, response) = try await URLSession.shared.data(for: request)
+
+        guard let httpResponse = response as? HTTPURLResponse,
+              httpResponse.statusCode == 200 else {
+            throw AuthError.tokenExchangeFailed
+        }
+
+        let tokenResponse = try JSONDecoder().decode(TokenResponse.self, from: data)
+        return AuthTokens(
+            accessToken: tokenResponse.access_token,
+            idToken: tokenResponse.id_token,
+            refreshToken: tokenResponse.refresh_token,
+            expiresAt: Date().addingTimeInterval(TimeInterval(tokenResponse.expires_in))
+        )
+    }
+
+    private func refreshTokens(refreshToken: String) async throws -> AuthTokens {
+        var request = URLRequest(url: URL(string: "https://\(config.domain)/oauth2/token")!)
+        request.httpMethod = "POST"
+        request.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
+
+        let body = [
+            "grant_type": "refresh_token",
+            "client_id": config.clientId,
+            "refresh_token": refreshToken
+        ]
+        request.httpBody = body.map { "\($0.key)=\($0.value)" }.joined(separator: "&").data(using: .utf8)
+
+        let (data, response) = try await URLSession.shared.data(for: request)
+
+        guard let httpResponse = response as? HTTPURLResponse,
+              httpResponse.statusCode == 200 else {
+            throw AuthError.tokenRefreshFailed
+        }
+
+        let tokenResponse = try JSONDecoder().decode(TokenResponse.self, from: data)
+        return AuthTokens(
+            accessToken: tokenResponse.access_token,
+            idToken: tokenResponse.id_token,
+            refreshToken: tokenResponse.refresh_token ?? refreshToken,
+            expiresAt: Date().addingTimeInterval(TimeInterval(tokenResponse.expires_in))
+        )
+    }
+}
+
+// MARK: - Supporting Types
+
+struct TokenResponse: Codable {
+    let access_token: String
+    let id_token: String
+    let refresh_token: String?
+    let expires_in: Int
+    let token_type: String
+}
+
+struct AuthTokens: Codable {
+    let accessToken: String
+    let idToken: String
+    let refreshToken: String
+    let expiresAt: Date
+
+    var isAccessTokenExpired: Bool {
+        Date() >= expiresAt.addingTimeInterval(-300) // 5 min buffer
+    }
+}
+
+enum AuthError: LocalizedError {
+    case failedToStartSession
+    case invalidCallback
+    case tokenExchangeFailed
+    case tokenRefreshFailed
+    case notAuthenticated
+    case notImplemented
+    case unknownError
+
+    var errorDescription: String? {
+        switch self {
+        case .failedToStartSession: return "Failed to start authentication session"
+        case .invalidCallback: return "Invalid authentication callback"
+        case .tokenExchangeFailed: return "Failed to exchange authorization code"
+        case .tokenRefreshFailed: return "Failed to refresh tokens"
+        case .notAuthenticated: return "Not authenticated"
+        case .notImplemented: return "Not implemented"
+        case .unknownError: return "Unknown error occurred"
+        }
+    }
+}
+
+// MARK: - Presentation Context Provider
+
+class ASWebAuthenticationPresentationContextProvider: NSObject, ASWebAuthenticationPresentationContextProviding {
+    static let shared = ASWebAuthenticationPresentationContextProvider()
+
+    func presentationAnchor(for session: ASWebAuthenticationSession) -> ASPresentationAnchor {
+        guard let scene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
+              let window = scene.windows.first else {
+            return ASPresentationAnchor()
+        }
+        return window
+    }
+}

--- a/ios/TimelessApp/TimelessApp/Utilities/CognitoConfig.swift
+++ b/ios/TimelessApp/TimelessApp/Utilities/CognitoConfig.swift
@@ -1,0 +1,34 @@
+import Foundation
+
+/// Cognito configuration
+/// Update these values from your Terraform output or AWS Console
+struct CognitoConfig {
+    static let shared = CognitoConfig()
+
+    /// AWS region where Cognito is deployed
+    let region = "ap-northeast-1"
+
+    /// Cognito User Pool ID
+    let userPoolId = "ap-northeast-1_xxx"
+
+    /// Cognito App Client ID
+    let clientId = "xxxxxxxxxxxxxxxxxx"
+
+    /// Cognito Hosted UI domain (without https://)
+    let domain = "your-domain.auth.ap-northeast-1.amazoncognito.com"
+
+    /// OAuth callback URL scheme (must match Info.plist)
+    let callbackURLScheme = "timeless"
+
+    /// OAuth callback URL
+    var callbackURL: String {
+        "\(callbackURLScheme)://callback"
+    }
+
+    /// OAuth sign-out callback URL
+    var signOutURL: String {
+        "\(callbackURLScheme)://signout"
+    }
+
+    private init() {}
+}

--- a/ios/TimelessApp/TimelessApp/Utilities/KeychainService.swift
+++ b/ios/TimelessApp/TimelessApp/Utilities/KeychainService.swift
@@ -1,0 +1,93 @@
+import Foundation
+import Security
+
+/// Keychain service for secure token storage
+actor KeychainService {
+    static let shared = KeychainService()
+
+    private let service = "com.timeless.app"
+    private let account = "auth_tokens"
+
+    private init() {}
+
+    func saveTokens(_ tokens: AuthTokens) throws {
+        let data = try JSONEncoder().encode(tokens)
+
+        // Delete existing item first
+        let deleteQuery: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account
+        ]
+        SecItemDelete(deleteQuery as CFDictionary)
+
+        // Add new item
+        let addQuery: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+            kSecValueData as String: data,
+            kSecAttrAccessible as String: kSecAttrAccessibleWhenUnlockedThisDeviceOnly
+        ]
+
+        let status = SecItemAdd(addQuery as CFDictionary, nil)
+        guard status == errSecSuccess else {
+            throw KeychainError.saveFailed(status)
+        }
+    }
+
+    func getTokens() throws -> AuthTokens? {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+            kSecReturnData as String: true
+        ]
+
+        var result: AnyObject?
+        let status = SecItemCopyMatching(query as CFDictionary, &result)
+
+        guard status == errSecSuccess else {
+            if status == errSecItemNotFound {
+                return nil
+            }
+            throw KeychainError.readFailed(status)
+        }
+
+        guard let data = result as? Data else {
+            return nil
+        }
+
+        return try JSONDecoder().decode(AuthTokens.self, from: data)
+    }
+
+    func deleteTokens() throws {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account
+        ]
+
+        let status = SecItemDelete(query as CFDictionary)
+        guard status == errSecSuccess || status == errSecItemNotFound else {
+            throw KeychainError.deleteFailed(status)
+        }
+    }
+}
+
+enum KeychainError: LocalizedError {
+    case saveFailed(OSStatus)
+    case readFailed(OSStatus)
+    case deleteFailed(OSStatus)
+
+    var errorDescription: String? {
+        switch self {
+        case .saveFailed(let status):
+            return "Failed to save to Keychain: \(status)"
+        case .readFailed(let status):
+            return "Failed to read from Keychain: \(status)"
+        case .deleteFailed(let status):
+            return "Failed to delete from Keychain: \(status)"
+        }
+    }
+}

--- a/ios/TimelessApp/TimelessApp/ViewModels/LoginViewModel.swift
+++ b/ios/TimelessApp/TimelessApp/ViewModels/LoginViewModel.swift
@@ -1,0 +1,40 @@
+import SwiftUI
+import AuthenticationServices
+
+/// ViewModel for login flow
+@MainActor
+class LoginViewModel: ObservableObject {
+    @Published var isLoading = false
+    @Published var showError = false
+    @Published var errorMessage = ""
+
+    private let authService = AuthService.shared
+
+    func signInWithGoogle() {
+        Task {
+            isLoading = true
+            defer { isLoading = false }
+
+            do {
+                try await authService.signInWithGoogle()
+            } catch {
+                errorMessage = error.localizedDescription
+                showError = true
+            }
+        }
+    }
+
+    func signInWithApple() {
+        Task {
+            isLoading = true
+            defer { isLoading = false }
+
+            do {
+                try await authService.signInWithApple()
+            } catch {
+                errorMessage = error.localizedDescription
+                showError = true
+            }
+        }
+    }
+}

--- a/ios/TimelessApp/TimelessApp/Views/Login/LoginView.swift
+++ b/ios/TimelessApp/TimelessApp/Views/Login/LoginView.swift
@@ -1,0 +1,96 @@
+import SwiftUI
+
+/// Login screen - Step 1 of onboarding flow
+struct LoginView: View {
+    @StateObject private var viewModel = LoginViewModel()
+
+    var body: some View {
+        ZStack {
+            // Background
+            Color.backgroundDark
+                .ignoresSafeArea()
+
+            VStack(spacing: Spacing.xl) {
+                Spacer()
+
+                // Logo and title
+                VStack(spacing: Spacing.md) {
+                    Image(systemName: "infinity")
+                        .font(.system(size: 64))
+                        .foregroundStyle(LinearGradient.neonGlow)
+
+                    Text("Timeless")
+                        .font(.displaySmall)
+                        .foregroundColor(.textPrimary)
+
+                    Text("Strive on your timeless journey")
+                        .font(.bodyLarge)
+                        .foregroundColor(.textSecondary)
+                }
+
+                Spacer()
+
+                // Login buttons
+                VStack(spacing: Spacing.md) {
+                    // Google Sign In
+                    Button(action: { viewModel.signInWithGoogle() }) {
+                        HStack(spacing: Spacing.sm) {
+                            Image(systemName: "g.circle.fill")
+                                .font(.title2)
+                            Text("Sign in with Google")
+                                .font(.titleMedium)
+                        }
+                        .foregroundColor(.textPrimary)
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, Spacing.md)
+                        .background(Color.surface)
+                        .cornerRadius(CornerRadius.lg)
+                        .overlay(
+                            RoundedRectangle(cornerRadius: CornerRadius.lg)
+                                .stroke(Color.surfaceBorder, lineWidth: 1)
+                        )
+                    }
+                    .buttonStyle(.plain)
+
+                    // Apple Sign In (optional)
+                    Button(action: { viewModel.signInWithApple() }) {
+                        HStack(spacing: Spacing.sm) {
+                            Image(systemName: "apple.logo")
+                                .font(.title2)
+                            Text("Sign in with Apple")
+                                .font(.titleMedium)
+                        }
+                        .foregroundColor(.textPrimary)
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, Spacing.md)
+                        .background(Color.surface)
+                        .cornerRadius(CornerRadius.lg)
+                        .overlay(
+                            RoundedRectangle(cornerRadius: CornerRadius.lg)
+                                .stroke(Color.surfaceBorder, lineWidth: 1)
+                        )
+                    }
+                    .buttonStyle(.plain)
+                }
+
+                // Terms
+                Text("By continuing, you agree to our Terms and Privacy Policy")
+                    .font(.bodySmall)
+                    .foregroundColor(.textMuted)
+                    .multilineTextAlignment(.center)
+                    .padding(.top, Spacing.md)
+            }
+            .padding(.horizontal, Spacing.lg)
+            .padding(.bottom, Spacing.xxl)
+        }
+        .alert("Error", isPresented: $viewModel.showError) {
+            Button("OK", role: .cancel) {}
+        } message: {
+            Text(viewModel.errorMessage)
+        }
+    }
+}
+
+#Preview {
+    LoginView()
+}


### PR DESCRIPTION
## Summary
Initialize iOS TimelessApp using **pure native implementation** - no external dependencies.

## Changes

### Project Structure (per NATIVE_APP_SPEC.md)
```
ios/TimelessApp/
├── TimelessApp.xcodeproj/
└── TimelessApp/
    ├── App/                    # Entry point
    ├── DesignSystem/
    │   ├── Tokens/             # Colors, Gradients, Typography, Spacing
    │   └── Components/         # PrimaryButton
    ├── Models/
    ├── ViewModels/             # LoginViewModel
    ├── Views/Login/            # LoginView
    ├── Utilities/              # AuthService, KeychainService, CognitoConfig
    └── Resources/Assets.xcassets/
```

### Authentication (Native)
- `ASWebAuthenticationSession` - Apple's OAuth solution for Cognito Hosted UI
- `Keychain Services API` - Secure token storage with `kSecAttrAccessibleWhenUnlockedThisDeviceOnly`
- Token refresh with 5-minute expiration buffer

### Design System (from figma-design-tokens.json)
- Tech Neon (科技霓虹風格) color palette
- Primary, Accent, Secondary color scales
- Gradient definitions
- Typography and spacing tokens

## Why No Amplify?
Per `web/NATIVE_APP_SPEC.md`:
```swift
// Dependencies (Swift Package Manager)
dependencies: [
    // None required for MVP (純原生實作)
]
```

## Test plan
- [ ] Open `ios/TimelessApp/TimelessApp.xcodeproj` in Xcode
- [ ] Build project (⌘B) - should succeed with no errors
- [ ] Run on simulator (⌘R) - should show login screen
- [ ] Verify design matches Tech Neon style

## Related Issues
Closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)