### PR TITLE
[#65] API README: endpoints, test coverage, and query samples

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -1,0 +1,137 @@
+# Ava Robotics API
+
+Go HTTP API service for the Ava Robotics platform, built with Go 1.22+ and the standard library.
+
+## Table of Contents
+
+- [Quick Start](#quick-start)
+- [API Endpoints](#api-endpoints)
+- [Testing & Coverage](#testing--coverage)
+- [Project Structure](#project-structure)
+- [Deployment](#deployment)
+
+---
+
+## Quick Start
+
+### Prerequisites
+
+- [Go 1.22+](https://go.dev/dl/)
+
+### Build & Run
+
+```bash
+# Run directly
+go run ./cmd/server/
+
+# Or build and run
+go build -o server ./cmd/server/
+./server
+```
+
+The server starts on port **8080** by default. Override with the `PORT` environment variable:
+
+```bash
+PORT=3000 go run ./cmd/server/
+```
+
+### Verify
+
+```bash
+curl -s http://localhost:8080/health
+# Expected: {}
+```
+
+## API Endpoints
+
+| Method | Path      | Description                        | Response |
+|--------|-----------|------------------------------------|----------|
+| GET    | `/health` | Health check — returns empty JSON  | 200 `{}` |
+
+### Query Samples
+
+#### GET /health
+
+Check if the API service is running.
+
+**Request:**
+
+```bash
+curl -s http://localhost:8080/health
+```
+
+**Response** (200 OK):
+
+```json
+{}
+```
+
+**Headers:**
+
+| Header         | Value              |
+|----------------|--------------------|
+| Content-Type   | `application/json` |
+
+**Error — Method Not Allowed** (405):
+
+```bash
+curl -s -o /dev/null -w "%{http_code}" -X POST http://localhost:8080/health
+# Returns: 405
+```
+
+> For full endpoint documentation, see [specs/009-api-readme/contracts/api-docs/health.md](../specs/009-api-readme/contracts/api-docs/health.md).
+
+## Testing & Coverage
+
+### Current Coverage
+
+| Package            | Coverage | Tests |
+|--------------------|----------|-------|
+| `internal/handler` | 100.0%   | 4     |
+| `cmd/server`       | 0.0%     | 0     |
+| **Total**          | **13.6%** | **4** |
+
+> `cmd/server` contains only the `main()` bootstrap function which is not unit-testable.
+
+### Run Tests
+
+```bash
+# Run all tests
+go test -v ./...
+
+# Run with race detection
+go test -v -race ./...
+```
+
+### Generate Coverage Report
+
+```bash
+# Generate coverage profile
+go test -coverprofile=coverage.out ./...
+
+# View coverage by function
+go tool cover -func=coverage.out
+
+# Open HTML coverage report in browser
+go tool cover -html=coverage.out
+```
+
+## Project Structure
+
+```
+api/
+├── cmd/
+│   └── server/
+│       └── main.go              # Server entry point, route registration, graceful shutdown
+├── internal/
+│   └── handler/
+│       ├── health.go            # GET /health handler
+│       └── health_test.go       # Handler unit tests (4 tests)
+├── .golangci.yml                # Linter configuration (golangci-lint v2)
+├── go.mod                       # Go module: github.com/avarobotics/api
+└── README.md                    # This file
+```
+
+## Deployment
+
+> ECR repository and container image details will be documented here after the CodeBuild pipeline is set up. See [issue #46](https://github.com/avachen2005/avarobotics/issues/46) for progress.

--- a/specs/009-api-readme/checklists/requirements.md
+++ b/specs/009-api-readme/checklists/requirements.md
@@ -1,0 +1,37 @@
+# Specification Quality Checklist: API README Documentation
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-02-07
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All items pass validation
+- ECR section is out of scope (depends on issue #46) but a placeholder will be included
+- This is a documentation-only feature — no code logic changes
+- Spec references existing issue #44 for traceability

--- a/specs/009-api-readme/contracts/api-docs/health.md
+++ b/specs/009-api-readme/contracts/api-docs/health.md
@@ -1,0 +1,83 @@
+# API Documentation: Health Check
+
+Health check endpoint to verify the API service is running.
+
+## Table of Contents
+
+- [Endpoint](#endpoint)
+- [Hostname](#hostname)
+- [Headers](#headers)
+- [Parameters](#parameters)
+- [Request](#request)
+- [Response](#response)
+- [Error Codes](#error-codes)
+
+---
+
+## Endpoint
+
+| Field        | Value                    |
+|--------------|--------------------------|
+| Method       | `GET`                    |
+| Path         | `/health`                |
+| Auth         | None                     |
+| Content-Type | `application/json`       |
+
+## Hostname
+
+| Environment | URL                        |
+|-------------|----------------------------|
+| Local       | `http://localhost:8080`    |
+| Production  | TBD (pending deployment)   |
+
+## Headers
+
+| Header         | Required | Value              | Description          |
+|----------------|----------|--------------------|----------------------|
+| Accept         | No       | `application/json` | Response format hint |
+
+No authentication headers required.
+
+## Parameters
+
+No query parameters or path parameters.
+
+## Request
+
+```bash
+curl -s http://localhost:8080/health
+```
+
+## Response
+
+### Success (200 OK)
+
+```json
+{}
+```
+
+| Field | Type   | Description |
+|-------|--------|-------------|
+| (none) | object | Empty JSON object indicating service is healthy |
+
+**Headers**:
+
+| Header         | Value              |
+|----------------|--------------------|
+| Content-Type   | `application/json` |
+
+### Method Not Allowed (405)
+
+Returned when using any method other than GET.
+
+```bash
+curl -s -X POST http://localhost:8080/health
+# Returns: 405 Method Not Allowed
+```
+
+## Error Codes
+
+| HTTP Status | Condition               | Response Body          |
+|-------------|-------------------------|------------------------|
+| 200         | Service is healthy      | `{}`                   |
+| 405         | Non-GET method used     | `Method Not Allowed\n` |

--- a/specs/009-api-readme/data-model.md
+++ b/specs/009-api-readme/data-model.md
@@ -1,0 +1,15 @@
+# Data Model: API README Documentation
+
+Data model for the API README feature.
+
+## Table of Contents
+
+- [Overview](#overview)
+
+---
+
+## Overview
+
+This is a documentation-only feature. No data entities, database schemas, or state transitions are involved. The deliverable is a single Markdown file (`api/README.md`) that documents the existing API.
+
+No data-model artifacts required.

--- a/specs/009-api-readme/plan.md
+++ b/specs/009-api-readme/plan.md
@@ -1,0 +1,79 @@
+# Implementation Plan: API README Documentation
+
+Create `api/README.md` as the single source of truth for developers — documenting all endpoints with curl samples, test coverage, quick start, and project structure.
+
+## Table of Contents
+
+- [Summary](#summary)
+- [Technical Context](#technical-context)
+- [Constitution Check](#constitution-check)
+- [Project Structure](#project-structure)
+
+---
+
+**Branch**: `009-api-readme` | **Date**: 2026-02-07 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/009-api-readme/spec.md`
+
+## Summary
+
+This is a documentation-only feature. The deliverable is a single file: `api/README.md`. No code changes are required. The README will document the current API state:
+
+- **1 endpoint**: `GET /health` → 200 `{}`
+- **Test coverage**: handler package 100%, total 13.6%
+- **Server config**: port 8080 (configurable via `PORT` env var), graceful shutdown
+- **Tech stack**: Go 1.22+, standard library only
+
+## Technical Context
+
+**Language/Version**: Markdown (documentation only)
+**Primary Dependencies**: None — this is a docs-only feature
+**Storage**: N/A
+**Testing**: Manual verification — README content matches actual API behavior
+**Target Platform**: GitHub repository (rendered by GitHub markdown)
+**Project Type**: Documentation
+**Performance Goals**: N/A
+**Constraints**: Must follow CLAUDE.md documentation standards (one-line summary, ToC, horizontal separator)
+**Scale/Scope**: Single file (`api/README.md`), ~100-150 lines
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+Constitution is not yet configured for this project (blank template). No gates to evaluate.
+
+**Pre-design**: PASS (no violations)
+**Post-design**: PASS (no violations)
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/009-api-readme/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output (minimal — docs feature)
+├── quickstart.md        # Phase 1 output
+├── contracts/           # Phase 1 output
+│   └── api-docs/
+│       └── health.md    # GET /health endpoint documentation
+└── tasks.md             # Phase 2 output (/speckit.tasks)
+```
+
+### Source Code (repository root)
+
+```text
+api/
+├── README.md            # ← NEW: The deliverable of this feature
+├── cmd/
+│   └── server/
+│       └── main.go      # Server entry point (port 8080, graceful shutdown)
+├── internal/
+│   └── handler/
+│       ├── health.go        # GET /health handler
+│       └── health_test.go   # 4 tests, 100% handler coverage
+├── .golangci.yml        # Linter configuration
+└── go.mod               # Module: github.com/avarobotics/api (Go 1.22)
+```
+
+**Structure Decision**: No new directories needed. Single file `api/README.md` added to existing structure.

--- a/specs/009-api-readme/quickstart.md
+++ b/specs/009-api-readme/quickstart.md
@@ -1,0 +1,37 @@
+# Quickstart: API README Documentation
+
+Quick guide for implementing the API README feature.
+
+## Table of Contents
+
+- [Prerequisites](#prerequisites)
+- [Implementation Steps](#implementation-steps)
+- [Validation](#validation)
+
+---
+
+## Prerequisites
+
+- Access to the repository
+- Go 1.22+ installed (to verify test coverage and run API locally)
+
+## Implementation Steps
+
+1. Create `api/README.md` with sections:
+   - One-line summary + Table of Contents (per CLAUDE.md standard)
+   - Quick Start (prerequisites, build, run)
+   - API Endpoints table with curl examples
+   - Testing & Coverage (commands + current percentage)
+   - Project Structure
+   - Deployment (placeholder for ECR, pending #46)
+
+2. Run `go test -coverprofile=coverage.out ./...` in `api/` to get current coverage
+3. Run `go tool cover -func=coverage.out` to get per-function breakdown
+4. Document the actual numbers in the README
+
+## Validation
+
+1. **Endpoints match**: Every route in `cmd/server/main.go` is listed in the README
+2. **Curl works**: Copy-paste each curl command from the README and verify it works against `go run ./cmd/server/`
+3. **Coverage matches**: Run `go test -cover ./...` and verify the README percentage matches
+4. **Quick start works**: Follow the README instructions from scratch and verify the server starts

--- a/specs/009-api-readme/research.md
+++ b/specs/009-api-readme/research.md
@@ -1,0 +1,52 @@
+# Research: API README Documentation
+
+Research findings for the API README feature.
+
+## Table of Contents
+
+- [README Structure](#readme-structure)
+- [Test Coverage Data](#test-coverage-data)
+- [API Endpoint Inventory](#api-endpoint-inventory)
+
+---
+
+## README Structure
+
+**Decision**: Follow the CLAUDE.md documentation standard (one-line summary, ToC, horizontal separator) and include sections for: Quick Start, API Endpoints, Test Coverage, Project Structure, and Deployment (placeholder).
+
+**Rationale**: Consistent with existing project documentation standards. Sections ordered by developer priority — endpoints first, then testing, then onboarding.
+
+**Alternatives considered**:
+- OpenAPI-generated docs: Overkill for 1 endpoint, adds tooling dependency
+- Wiki-based docs: Not co-located with code, gets stale faster
+- Godoc only: Doesn't provide curl samples or quick start
+
+## Test Coverage Data
+
+**Decision**: Document coverage by package with actual measured percentages.
+
+**Current measurements** (2026-02-07):
+
+| Package | Coverage | Tests |
+|---------|----------|-------|
+| `internal/handler` | 100.0% | 4 tests (3 unit + 1 table-driven with 3 sub-tests) |
+| `cmd/server` | 0.0% | No tests (server bootstrap, not unit-testable) |
+| **Total** | **13.6%** | **4 test functions** |
+
+**Rationale**: Go's built-in `go test -coverprofile` is the standard tool. Total percentage is low because `cmd/server/main.go` bootstrap code isn't tested, but all handler logic is 100% covered.
+
+## API Endpoint Inventory
+
+**Decision**: Document all endpoints from `cmd/server/main.go` route registration.
+
+**Current endpoints** (2026-02-07):
+
+| Method | Path | Handler | Response | Status |
+|--------|------|---------|----------|--------|
+| GET | `/health` | `handler.HealthHandler` | 200 `{}` | Implemented |
+
+**Server configuration**:
+- Default port: 8080
+- Port override: `PORT` environment variable
+- Timeouts: Read 10s, Write 10s, Idle 60s
+- Graceful shutdown: 30-second timeout on SIGINT/SIGTERM

--- a/specs/009-api-readme/spec.md
+++ b/specs/009-api-readme/spec.md
@@ -1,0 +1,98 @@
+# Feature Specification: API README Documentation
+
+Create a comprehensive README.md for the API directory that serves as the single source of truth for developers, including test coverage, all API endpoints, and query samples.
+
+## Table of Contents
+
+- [User Scenarios & Testing](#user-scenarios--testing-mandatory)
+- [Requirements](#requirements-mandatory)
+- [Success Criteria](#success-criteria-mandatory)
+
+---
+
+**Feature Branch**: `009-api-readme`
+**Created**: 2026-02-07
+**Status**: Draft
+**Input**: User description: "api/ 要有 README.md 並且要有 test coverage 還有所有 api path 跟 query sample"
+**Related Issue**: [#44](https://github.com/avachen2005/avarobotics/issues/44)
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - View API Endpoints and Query Samples (Priority: P1) 🎯 MVP
+
+A developer joining the team or integrating with the API opens `api/README.md` and can immediately see every available endpoint — its HTTP method, path, description, request/response format, and a ready-to-use curl command they can copy-paste to test it.
+
+**Why this priority**: This is the core value — developers need to know what endpoints exist and how to call them without reading source code.
+
+**Independent Test**: Open `api/README.md` and verify every currently implemented endpoint is listed with method, path, description, and a working curl example.
+
+**Acceptance Scenarios**:
+
+1. **Given** a developer opens `api/README.md`, **When** they look at the API endpoints section, **Then** they see a table listing every endpoint with HTTP method, path, and description
+2. **Given** a developer wants to test an endpoint, **When** they find the endpoint in the README, **Then** they see a curl command example they can copy-paste and run
+3. **Given** a new endpoint is added to the API, **When** the PR is reviewed, **Then** the README must also include the new endpoint's documentation
+
+---
+
+### User Story 2 - View Test Coverage (Priority: P2)
+
+A developer or reviewer opens `api/README.md` and can see the current test coverage status for the API, including how to run tests and generate coverage reports locally.
+
+**Why this priority**: Test coverage gives confidence in code quality but is secondary to knowing what the API can do.
+
+**Independent Test**: Open `api/README.md` and verify test coverage information is present, and the documented commands to run tests and generate coverage work correctly.
+
+**Acceptance Scenarios**:
+
+1. **Given** a developer opens `api/README.md`, **When** they look at the testing section, **Then** they see the current test coverage percentage
+2. **Given** a developer wants to run tests locally, **When** they follow the README instructions, **Then** they can run tests and generate a coverage report
+
+---
+
+### User Story 3 - Quick Start and Project Overview (Priority: P3)
+
+A developer new to the project opens `api/README.md` and can quickly understand the project structure, prerequisites, and how to run the API locally.
+
+**Why this priority**: Onboarding information is important but developers can usually figure this out from the code. Having it documented saves time.
+
+**Independent Test**: A developer with Go installed can follow the README to start the API server locally within 2 minutes.
+
+**Acceptance Scenarios**:
+
+1. **Given** a developer opens `api/README.md`, **When** they look at the quick start section, **Then** they see prerequisites (Go version) and commands to build and run the server
+2. **Given** a developer follows the quick start instructions, **When** they run the documented commands, **Then** the API server starts successfully on the documented port
+
+---
+
+### Edge Cases
+
+- What happens when a new endpoint is added but the README is not updated? The PR review checklist should catch this.
+- What happens when test coverage changes? Coverage should be re-measured and updated as part of the PR process.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: README MUST list all API endpoints in a table with HTTP method, path, and description
+- **FR-002**: README MUST include a curl command example for each endpoint showing request and expected response
+- **FR-003**: README MUST display the current test coverage percentage
+- **FR-004**: README MUST include instructions to run tests and generate coverage reports locally
+- **FR-005**: README MUST include quick start instructions: prerequisites, build command, and run command
+- **FR-006**: README MUST document the default port and how to configure it via environment variable
+- **FR-007**: README MUST include project directory structure overview
+
+### Assumptions
+
+- Test coverage is measured using Go's built-in coverage tooling
+- The README documents the current state of the API at time of writing (1 endpoint: `GET /health`)
+- ECR information will be added when the CodeBuild pipeline (issue #46) is implemented — a placeholder section will be included
+- Developers have Go 1.22+ installed as a prerequisite
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Every implemented API endpoint is documented in the README with method, path, description, and curl example
+- **SC-002**: A new developer can start the API server locally by following only the README instructions
+- **SC-003**: Test coverage percentage is documented and matches actual coverage when tests are run
+- **SC-004**: README is the single source of truth — no other document is needed to understand and use the API

--- a/specs/009-api-readme/tasks.md
+++ b/specs/009-api-readme/tasks.md
@@ -1,0 +1,142 @@
+# Tasks: API README Documentation
+
+Create `api/README.md` with API endpoints, curl samples, test coverage, quick start, and project structure.
+
+## Table of Contents
+
+- [Phase 1: Setup](#phase-1-setup)
+- [Phase 2: User Story 1](#phase-2-user-story-1---api-endpoints--query-samples-priority-p1--mvp)
+- [Phase 3: User Story 2](#phase-3-user-story-2---test-coverage-priority-p2)
+- [Phase 4: User Story 3](#phase-4-user-story-3---quick-start--project-overview-priority-p3)
+- [Phase 5: Polish](#phase-5-polish--cross-cutting-concerns)
+- [Dependencies & Execution Order](#dependencies--execution-order)
+- [Implementation Strategy](#implementation-strategy)
+
+---
+
+**Input**: Design documents from `/specs/009-api-readme/`
+**Prerequisites**: plan.md (required), spec.md (required for user stories), research.md, contracts/api-docs/health.md
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing of each story.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2, US3)
+- Include exact file paths in descriptions
+
+## Phase 1: Setup
+
+**Purpose**: Create the README file with document structure (title, ToC, separator per CLAUDE.md standard)
+
+- [x] T001 Create `api/README.md` with title "Ava Robotics API", one-line summary, Table of Contents linking to all sections (Quick Start, API Endpoints, Testing & Coverage, Project Structure, Deployment), and horizontal separator per CLAUDE.md documentation standard
+
+---
+
+## Phase 2: User Story 1 - API Endpoints & Query Samples (Priority: P1) 🎯 MVP
+
+**Goal**: Every implemented endpoint is listed with method, path, description, and a copy-paste curl example.
+
+**Independent Test**: Open `api/README.md` and verify the endpoints table lists `GET /health`, and the curl example returns `{}` when run against a local server.
+
+### Implementation for User Story 1
+
+- [x] T002 [US1] Add "API Endpoints" section to `api/README.md` with a table (columns: Method, Path, Description, Response) listing `GET /health` → 200 `{}`
+- [x] T003 [US1] Add "Query Samples" subsection to `api/README.md` under API Endpoints with a curl command example for `GET /health` showing the full request and expected response, referencing `contracts/api-docs/health.md` for details
+
+**Checkpoint**: At this point, developers can see all endpoints and test them with curl. This is the MVP.
+
+---
+
+## Phase 3: User Story 2 - Test Coverage (Priority: P2)
+
+**Goal**: Developers can see current test coverage and know how to run tests locally.
+
+**Independent Test**: Open `api/README.md`, verify coverage percentage is listed, then run the documented test commands in `api/` and confirm output matches.
+
+### Implementation for User Story 2
+
+- [x] T004 [US2] Run `go test -coverprofile=coverage.out ./...` and `go tool cover -func=coverage.out` in `api/` to measure current coverage, then add "Testing & Coverage" section to `api/README.md` with:
+  - Current coverage table by package (handler: 100%, cmd/server: 0%, total: 13.6%)
+  - Commands to run tests: `go test -v ./...`
+  - Commands to generate coverage report: `go test -coverprofile=coverage.out ./...` and `go tool cover -func=coverage.out`
+
+**Checkpoint**: At this point, developers can see test coverage and run tests locally.
+
+---
+
+## Phase 4: User Story 3 - Quick Start & Project Overview (Priority: P3)
+
+**Goal**: A new developer can understand the project and run the API locally by following only the README.
+
+**Independent Test**: Follow the README quick start instructions from scratch — the server should start on port 8080 and `curl localhost:8080/health` returns `{}`.
+
+### Implementation for User Story 3
+
+- [x] T005 [P] [US3] Add "Quick Start" section to `api/README.md` with: prerequisites (Go 1.22+), build command (`go build ./cmd/server/`), run command (`go run ./cmd/server/`), port configuration (`PORT` env var, default 8080), and verification curl command
+- [x] T006 [P] [US3] Add "Project Structure" section to `api/README.md` with directory tree showing `cmd/server/`, `internal/handler/`, `.golangci.yml`, `go.mod` and brief descriptions of each
+- [x] T007 [US3] Add "Deployment" placeholder section to `api/README.md` noting ECR info will be added after CodeBuild setup (issue #46)
+
+**Checkpoint**: All user stories complete — README is the single source of truth for the API.
+
+---
+
+## Phase 5: Polish & Cross-Cutting Concerns
+
+**Purpose**: Validation and final checks
+
+- [x] T008 Validate README by starting the API server (`go run ./cmd/server/` in `api/`), running each curl example from the README, and verifying the output matches the documented response
+- [x] T009 Validate coverage by running the test commands from the README and confirming the percentage matches the documented value in `api/README.md`
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies — can start immediately
+- **User Story 1 (Phase 2)**: Depends on T001 (README file exists)
+- **User Story 2 (Phase 3)**: Depends on T001 (README file exists). Independent of US1
+- **User Story 3 (Phase 4)**: Depends on T001 (README file exists). Independent of US1 and US2
+- **Polish (Phase 5)**: Depends on all user stories complete
+
+### User Story Dependencies
+
+- **User Story 1 (P1)**: Independent — only needs Setup
+- **User Story 2 (P2)**: Independent — only needs Setup
+- **User Story 3 (P3)**: Independent — only needs Setup
+
+### Parallel Opportunities
+
+- T002 and T003 are sequential (T003 adds subsection under T002's section)
+- T005, T006 can run in parallel (different sections of the README)
+- US1, US2, US3 could be parallelized after Setup (different sections, no conflicts) but since they're all in one file, sequential is safer to avoid merge conflicts
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1: Setup (T001)
+2. Complete Phase 2: User Story 1 (T002, T003)
+3. **STOP and VALIDATE**: Verify endpoints table and curl examples work
+4. This alone delivers value — every developer can see API endpoints and test them
+
+### Incremental Delivery
+
+1. Setup (T001) → README file created
+2. Add User Story 1 (T002-T003) → Endpoints + curl samples → **MVP!**
+3. Add User Story 2 (T004) → Test coverage documented
+4. Add User Story 3 (T005-T007) → Quick start + project structure + deployment placeholder
+5. Polish (T008-T009) → Validate everything is accurate
+
+---
+
+## Notes
+
+- [P] tasks = different sections, no dependencies
+- [Story] label maps task to specific user story for traceability
+- All tasks modify a single file (`api/README.md`) — execute sequentially to avoid conflicts
+- Commit after each user story phase for clean history
+- This is a docs-only feature — no code changes required


### PR DESCRIPTION
## Summary
- Create `api/README.md` as the single source of truth for API developers
- Document all endpoints with curl samples, test coverage, quick start, and project structure

## Changes
- `api/README.md` — New file with Quick Start, API Endpoints, Testing & Coverage, Project Structure, Deployment sections
- `specs/009-api-readme/` — Feature specification, plan, research, contracts, tasks, and checklist

## Testing
- Validated curl examples against live server: `GET /health` → `{}` (PASS), `POST /health` → 405 (PASS)
- Validated coverage matches: 13.6% total (PASS)

Closes #65

🤖 Generated with [Claude Code](https://claude.com/claude-code)