### PR TITLE
feat: add iOS design token system mirroring web Figma tokens

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,6 +93,7 @@ IAM User (透過 assume role 獲取權限)
 - YAML (GitHub Actions workflows), HCL (Terraform for IAM), Go 1.22 (golangci-lint config) + `actions/checkout@v4`, `actions/setup-go@v5`, `golangci/golangci-lint-action@v4`, `aws-actions/configure-aws-credentials@v4`, `aws-actions/aws-codebuild-run-build@v1` (008-api-ci-cd-pipeline)
 - Go 1.22 (API), HCL (Terraform >= 1.5.0) + AWS Provider ~> 5.0, Docker (multi-stage build) (040-codebuild-ecr-api)
 - ECR (container images), CloudWatch Logs (build logs) (040-codebuild-ecr-api)
+- Swift 5.9+ + SwiftUI (system framework), XCTest (system framework) — no third-party dependencies (042-ios-design-tokens)
 
 ## GitHub Issue Workflow (實作時必須遵循)
 
@@ -239,7 +240,6 @@ gh project item-list 4 --owner avachen2005 --format json | jq '.items[] | select
 | #8 | Phase 7: Polish | PVTI_lAHOAHxvcs4BN-akzgknPFE |
 
 ## Recent Changes
+- 042-ios-design-tokens: Added Swift 5.9+ + SwiftUI (system framework), XCTest (system framework) — no third-party dependencies
 - 008-api-ci-cd-pipeline: Added YAML (GitHub Actions workflows), HCL (Terraform for IAM), Go 1.22 (golangci-lint config) + `actions/checkout@v4`, `actions/setup-go@v5`, `golangci/golangci-lint-action@v4`, `aws-actions/configure-aws-credentials@v4`, `aws-actions/aws-codebuild-run-build@v1`
 - 040-codebuild-ecr-api: Added Go 1.22 (API), HCL (Terraform >= 1.5.0) + AWS Provider ~> 5.0, Docker (multi-stage build)
-- 001-ci-lint-test: Added YAML (GitHub Actions), Go 1.22 (API), TypeScript 5.9 (Web), HCL (Terraform) + `dorny/paths-filter@v3`, `golangci/golangci-lint-action@v7`, `hashicorp/setup-terraform@v3`, `actions/setup-go@v5`, `actions/setup-node@v4`
-- 006-cognito-app-auth: Added Go JWT validation (golang-jwt/jwt/v5), Swift 5.9+ (iOS), Kotlin 1.9+ (Android), secure token storage

--- a/ios/AvaRobotics/DesignSystem/Components/ButtonStyles.swift
+++ b/ios/AvaRobotics/DesignSystem/Components/ButtonStyles.swift
@@ -1,0 +1,56 @@
+import SwiftUI
+
+struct BrandPrimaryButtonStyle: ButtonStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .typography(.buttonMedium)
+            .foregroundStyle(ColorToken.Semantic.white)
+            .padding(.horizontal, SpacingToken.lg)
+            .padding(.vertical, SpacingToken.md)
+            .background(GradientToken.primary)
+            .clipShape(Capsule())
+            .tokenShadow(.md)
+            .opacity(configuration.isPressed ? 0.8 : 1.0)
+    }
+}
+
+struct BrandSecondaryButtonStyle: ButtonStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .typography(.buttonMedium)
+            .foregroundStyle(ColorToken.Semantic.white)
+            .padding(.horizontal, SpacingToken.lg)
+            .padding(.vertical, SpacingToken.md)
+            .background(GradientToken.accent)
+            .clipShape(Capsule())
+            .tokenShadow(.md)
+            .opacity(configuration.isPressed ? 0.8 : 1.0)
+    }
+}
+
+struct BrandOutlineButtonStyle: ButtonStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .typography(.buttonMedium)
+            .foregroundStyle(ColorToken.Primary.p500)
+            .padding(.horizontal, SpacingToken.lg)
+            .padding(.vertical, SpacingToken.md)
+            .background(
+                Capsule()
+                    .strokeBorder(ColorToken.Primary.p500, lineWidth: ShapeToken.BorderWidth.regular)
+            )
+            .opacity(configuration.isPressed ? 0.6 : 1.0)
+    }
+}
+
+extension ButtonStyle where Self == BrandPrimaryButtonStyle {
+    static var brandPrimary: BrandPrimaryButtonStyle { BrandPrimaryButtonStyle() }
+}
+
+extension ButtonStyle where Self == BrandSecondaryButtonStyle {
+    static var brandSecondary: BrandSecondaryButtonStyle { BrandSecondaryButtonStyle() }
+}
+
+extension ButtonStyle where Self == BrandOutlineButtonStyle {
+    static var brandOutline: BrandOutlineButtonStyle { BrandOutlineButtonStyle() }
+}

--- a/ios/AvaRobotics/DesignSystem/Components/CardModifier.swift
+++ b/ios/AvaRobotics/DesignSystem/Components/CardModifier.swift
@@ -1,0 +1,33 @@
+import SwiftUI
+
+enum CardPadding {
+    case small
+    case medium
+    case large
+
+    var value: CGFloat {
+        switch self {
+        case .small: return SpacingToken.md
+        case .medium: return SpacingToken.lg
+        case .large: return SpacingToken.xl
+        }
+    }
+}
+
+struct CardModifier: ViewModifier {
+    let padding: CardPadding
+
+    func body(content: Content) -> some View {
+        content
+            .padding(padding.value)
+            .background(ColorToken.Semantic.white)
+            .clipShape(RoundedRectangle(cornerRadius: ShapeToken.CornerRadius.xxl))
+            .tokenShadow(.lg)
+    }
+}
+
+extension View {
+    func cardStyle(padding: CardPadding = .medium) -> some View {
+        modifier(CardModifier(padding: padding))
+    }
+}

--- a/ios/AvaRobotics/DesignSystem/Components/TextFieldStyles.swift
+++ b/ios/AvaRobotics/DesignSystem/Components/TextFieldStyles.swift
@@ -1,0 +1,32 @@
+import SwiftUI
+
+struct BrandedTextFieldStyle: TextFieldStyle {
+    @FocusState private var isFocused: Bool
+    var isError: Bool = false
+
+    func _body(configuration: TextField<Self._Label>) -> some View {
+        configuration
+            .typography(.input)
+            .padding(.vertical, 12)
+            .padding(.horizontal, SpacingToken.md)
+            .background(
+                RoundedRectangle(cornerRadius: ShapeToken.CornerRadius.lg)
+                    .strokeBorder(borderColor, lineWidth: ShapeToken.BorderWidth.regular)
+            )
+            .focused($isFocused)
+    }
+
+    private var borderColor: Color {
+        if isError {
+            return ColorToken.Status.error
+        } else if isFocused {
+            return ColorToken.Primary.p500
+        } else {
+            return ColorToken.Neutral.n200
+        }
+    }
+}
+
+extension TextFieldStyle where Self == BrandedTextFieldStyle {
+    static var branded: BrandedTextFieldStyle { BrandedTextFieldStyle() }
+}

--- a/ios/AvaRobotics/DesignSystem/Extensions/Color+Hex.swift
+++ b/ios/AvaRobotics/DesignSystem/Extensions/Color+Hex.swift
@@ -1,0 +1,30 @@
+import SwiftUI
+
+extension Color {
+    init(hex: String) {
+        let hex = hex.trimmingCharacters(in: CharacterSet.alphanumerics.inverted)
+        var int: UInt64 = 0
+        Scanner(string: hex).scanHexInt64(&int)
+
+        let r, g, b, a: Double
+        switch hex.count {
+        case 6:
+            r = Double((int >> 16) & 0xFF) / 255.0
+            g = Double((int >> 8) & 0xFF) / 255.0
+            b = Double(int & 0xFF) / 255.0
+            a = 1.0
+        case 8:
+            r = Double((int >> 24) & 0xFF) / 255.0
+            g = Double((int >> 16) & 0xFF) / 255.0
+            b = Double((int >> 8) & 0xFF) / 255.0
+            a = Double(int & 0xFF) / 255.0
+        default:
+            r = 0
+            g = 0
+            b = 0
+            a = 1.0
+        }
+
+        self.init(.sRGB, red: r, green: g, blue: b, opacity: a)
+    }
+}

--- a/ios/AvaRobotics/DesignSystem/Extensions/View+DesignSystem.swift
+++ b/ios/AvaRobotics/DesignSystem/Extensions/View+DesignSystem.swift
@@ -1,0 +1,11 @@
+import SwiftUI
+
+extension View {
+    func typography(_ token: TypographyToken) -> some View {
+        modifier(TypographyModifier(token: token))
+    }
+
+    func tokenShadow(_ token: ShadowToken) -> some View {
+        modifier(ShadowModifier(token: token))
+    }
+}

--- a/ios/AvaRobotics/DesignSystem/Tokens/ColorToken.swift
+++ b/ios/AvaRobotics/DesignSystem/Tokens/ColorToken.swift
@@ -1,0 +1,62 @@
+import SwiftUI
+
+enum ColorToken {
+    enum Primary {
+        static let p50 = Color(hex: "#f5f3ff")
+        static let p100 = Color(hex: "#ede9fe")
+        static let p200 = Color(hex: "#ddd6fe")
+        static let p300 = Color(hex: "#c4b5fd")
+        static let p400 = Color(hex: "#a78bfa")
+        static let p500 = Color(hex: "#8b5cf6")
+        static let p600 = Color(hex: "#7c3aed")
+        static let p700 = Color(hex: "#6d28d9")
+        static let p800 = Color(hex: "#5b21b6")
+        static let p900 = Color(hex: "#4c1d95")
+    }
+
+    enum Accent {
+        static let a50 = Color(hex: "#fdf4ff")
+        static let a100 = Color(hex: "#fae8ff")
+        static let a200 = Color(hex: "#f5d0fe")
+        static let a300 = Color(hex: "#f0abfc")
+        static let a400 = Color(hex: "#e879f9")
+        static let a500 = Color(hex: "#d946ef")
+        static let a600 = Color(hex: "#c026d3")
+        static let a700 = Color(hex: "#a21caf")
+    }
+
+    enum Secondary {
+        static let s50 = Color(hex: "#ecfeff")
+        static let s100 = Color(hex: "#cffafe")
+        static let s200 = Color(hex: "#a5f3fc")
+        static let s300 = Color(hex: "#67e8f9")
+        static let s400 = Color(hex: "#22d3ee")
+        static let s500 = Color(hex: "#06b6d4")
+        static let s600 = Color(hex: "#0891b2")
+    }
+
+    enum Neutral {
+        static let n50 = Color(hex: "#f8fafc")
+        static let n100 = Color(hex: "#f1f5f9")
+        static let n200 = Color(hex: "#e2e8f0")
+        static let n300 = Color(hex: "#cbd5e1")
+        static let n400 = Color(hex: "#94a3b8")
+        static let n500 = Color(hex: "#64748b")
+        static let n600 = Color(hex: "#475569")
+        static let n700 = Color(hex: "#334155")
+        static let n800 = Color(hex: "#1e293b")
+        static let n900 = Color(hex: "#0f172a")
+    }
+
+    enum Semantic {
+        static let white = Color(hex: "#ffffff")
+        static let black = Color(hex: "#000000")
+    }
+
+    enum Status {
+        static let success = Color(hex: "#22c55e")
+        static let warning = Color(hex: "#f59e0b")
+        static let error = Color(hex: "#ef4444")
+        static let info = Color(hex: "#3b82f6")
+    }
+}

--- a/ios/AvaRobotics/DesignSystem/Tokens/GradientToken.swift
+++ b/ios/AvaRobotics/DesignSystem/Tokens/GradientToken.swift
@@ -1,0 +1,76 @@
+import SwiftUI
+
+enum GradientToken {
+    static let primary = LinearGradient(
+        colors: primaryStops,
+        startPoint: .topLeading,
+        endPoint: .bottomTrailing
+    )
+
+    static let accent = LinearGradient(
+        colors: accentStops,
+        startPoint: .topLeading,
+        endPoint: .bottomTrailing
+    )
+
+    static let secondary = LinearGradient(
+        colors: secondaryStops,
+        startPoint: .topLeading,
+        endPoint: .bottomTrailing
+    )
+
+    static let neon = LinearGradient(
+        colors: neonStops,
+        startPoint: .topLeading,
+        endPoint: .bottomTrailing
+    )
+
+    static let tech = LinearGradient(
+        colors: techStops,
+        startPoint: .topLeading,
+        endPoint: .bottomTrailing
+    )
+
+    static let background = LinearGradient(
+        colors: backgroundStops,
+        startPoint: .topLeading,
+        endPoint: .bottomTrailing
+    )
+
+    // Exposed for testability
+    static let primaryStops: [Color] = [
+        ColorToken.Primary.p500,
+        ColorToken.Primary.p700,
+        ColorToken.Primary.p800
+    ]
+
+    static let accentStops: [Color] = [
+        ColorToken.Accent.a400,
+        ColorToken.Accent.a500,
+        ColorToken.Accent.a600
+    ]
+
+    static let secondaryStops: [Color] = [
+        ColorToken.Secondary.s400,
+        ColorToken.Secondary.s500,
+        ColorToken.Secondary.s600
+    ]
+
+    static let neonStops: [Color] = [
+        ColorToken.Primary.p500,
+        ColorToken.Accent.a500,
+        ColorToken.Secondary.s400
+    ]
+
+    static let techStops: [Color] = [
+        ColorToken.Primary.p700,
+        ColorToken.Accent.a700,
+        ColorToken.Secondary.s600
+    ]
+
+    static let backgroundStops: [Color] = [
+        ColorToken.Primary.p50,
+        ColorToken.Accent.a50,
+        ColorToken.Secondary.s50
+    ]
+}

--- a/ios/AvaRobotics/DesignSystem/Tokens/OpacityToken.swift
+++ b/ios/AvaRobotics/DesignSystem/Tokens/OpacityToken.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+enum OpacityToken {
+    static let opacity5: Double = 0.05
+    static let opacity10: Double = 0.10
+    static let opacity20: Double = 0.20
+    static let opacity30: Double = 0.30
+    static let opacity40: Double = 0.40
+    static let opacity50: Double = 0.50
+    static let opacity60: Double = 0.60
+    static let opacity70: Double = 0.70
+    static let opacity80: Double = 0.80
+    static let opacity90: Double = 0.90
+    static let opacity100: Double = 1.00
+}

--- a/ios/AvaRobotics/DesignSystem/Tokens/ShadowToken.swift
+++ b/ios/AvaRobotics/DesignSystem/Tokens/ShadowToken.swift
@@ -1,0 +1,63 @@
+import SwiftUI
+
+enum ShadowToken: CaseIterable {
+    case sm
+    case md
+    case lg
+    case xl
+    case xxl
+    case glowPurple
+    case glowPink
+    case glowCyan
+
+    var radius: CGFloat {
+        switch self {
+        case .sm: return 2
+        case .md: return 6
+        case .lg: return 15
+        case .xl: return 25
+        case .xxl: return 50
+        case .glowPurple, .glowPink, .glowCyan: return 30
+        }
+    }
+
+    var x: CGFloat {
+        switch self {
+        case .sm, .md, .lg, .xl, .xxl: return 0
+        case .glowPurple, .glowPink, .glowCyan: return 0
+        }
+    }
+
+    var y: CGFloat {
+        switch self {
+        case .sm: return 1
+        case .md: return 4
+        case .lg: return 10
+        case .xl: return 20
+        case .xxl: return 25
+        case .glowPurple, .glowPink, .glowCyan: return 0
+        }
+    }
+
+    var color: Color {
+        switch self {
+        case .sm: return Color.black.opacity(OpacityToken.opacity5)
+        case .md: return Color.black.opacity(OpacityToken.opacity10)
+        case .lg: return Color.black.opacity(OpacityToken.opacity10)
+        case .xl: return Color.black.opacity(OpacityToken.opacity10)
+        case .xxl: return Color.black.opacity(0.25)
+        case .glowPurple: return Color(hex: "#8b5cf6").opacity(OpacityToken.opacity50)
+        case .glowPink: return Color(hex: "#d946ef").opacity(OpacityToken.opacity50)
+        case .glowCyan: return Color(hex: "#22d3ee").opacity(OpacityToken.opacity50)
+        }
+    }
+}
+
+struct ShadowModifier: ViewModifier {
+    let token: ShadowToken
+
+    func body(content: Content) -> some View {
+        content
+            .shadow(color: token.color, radius: token.radius, x: token.x, y: token.y)
+    }
+}

--- a/ios/AvaRobotics/DesignSystem/Tokens/ShapeToken.swift
+++ b/ios/AvaRobotics/DesignSystem/Tokens/ShapeToken.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+enum ShapeToken {
+    enum CornerRadius {
+        static let none: CGFloat = 0
+        static let sm: CGFloat = 6
+        static let md: CGFloat = 8
+        static let lg: CGFloat = 12
+        static let xl: CGFloat = 16
+        static let xxl: CGFloat = 24
+        static let xxxl: CGFloat = 28
+        static let full: CGFloat = 9999
+    }
+
+    enum BorderWidth {
+        static let thin: CGFloat = 1
+        static let regular: CGFloat = 2
+    }
+}

--- a/ios/AvaRobotics/DesignSystem/Tokens/SpacingToken.swift
+++ b/ios/AvaRobotics/DesignSystem/Tokens/SpacingToken.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+enum SpacingToken {
+    static let xs: CGFloat = 4
+    static let sm: CGFloat = 8
+    static let md: CGFloat = 16
+    static let lg: CGFloat = 24
+    static let xl: CGFloat = 32
+    static let xxl: CGFloat = 48
+    static let xxxl: CGFloat = 64
+}

--- a/ios/AvaRobotics/DesignSystem/Tokens/TypographyToken.swift
+++ b/ios/AvaRobotics/DesignSystem/Tokens/TypographyToken.swift
@@ -1,0 +1,159 @@
+import SwiftUI
+
+enum TypographyToken: CaseIterable {
+    case display1
+    case display2
+    case heading1
+    case heading2
+    case heading3
+    case bodyLarge
+    case bodyRegular
+    case bodyMedium
+    case bodySemibold
+    case bodySmall
+    case bodySmallMedium
+    case caption
+    case captionMedium
+    case buttonLarge
+    case buttonMedium
+    case buttonSmall
+    case label
+    case input
+
+    var size: CGFloat {
+        switch self {
+        case .display1: return 36
+        case .display2: return 30
+        case .heading1: return 24
+        case .heading2: return 20
+        case .heading3: return 18
+        case .bodyLarge: return 18
+        case .bodyRegular: return 16
+        case .bodyMedium: return 16
+        case .bodySemibold: return 16
+        case .bodySmall: return 14
+        case .bodySmallMedium: return 14
+        case .caption: return 12
+        case .captionMedium: return 12
+        case .buttonLarge: return 18
+        case .buttonMedium: return 16
+        case .buttonSmall: return 14
+        case .label: return 14
+        case .input: return 16
+        }
+    }
+
+    var weight: Font.Weight {
+        switch self {
+        case .display1: return .bold
+        case .display2: return .bold
+        case .heading1: return .semibold
+        case .heading2: return .semibold
+        case .heading3: return .semibold
+        case .bodyLarge: return .regular
+        case .bodyRegular: return .regular
+        case .bodyMedium: return .medium
+        case .bodySemibold: return .semibold
+        case .bodySmall: return .regular
+        case .bodySmallMedium: return .medium
+        case .caption: return .regular
+        case .captionMedium: return .medium
+        case .buttonLarge: return .semibold
+        case .buttonMedium: return .medium
+        case .buttonSmall: return .medium
+        case .label: return .medium
+        case .input: return .regular
+        }
+    }
+
+    var lineSpacing: CGFloat {
+        switch self {
+        case .display1: return 4
+        case .display2: return 4
+        case .heading1: return 2
+        case .heading2: return 2
+        case .heading3: return 2
+        case .bodyLarge: return 4
+        case .bodyRegular: return 4
+        case .bodyMedium: return 4
+        case .bodySemibold: return 4
+        case .bodySmall: return 3
+        case .bodySmallMedium: return 3
+        case .caption: return 2
+        case .captionMedium: return 2
+        case .buttonLarge: return 0
+        case .buttonMedium: return 0
+        case .buttonSmall: return 0
+        case .label: return 0
+        case .input: return 0
+        }
+    }
+
+    var tracking: CGFloat {
+        switch self {
+        case .display1: return -0.5
+        case .display2: return -0.5
+        case .heading1: return 0
+        case .heading2: return 0
+        case .heading3: return 0
+        case .bodyLarge: return 0
+        case .bodyRegular: return 0
+        case .bodyMedium: return 0
+        case .bodySemibold: return 0
+        case .bodySmall: return 0
+        case .bodySmallMedium: return 0
+        case .caption: return 0
+        case .captionMedium: return 0
+        case .buttonLarge: return 0.5
+        case .buttonMedium: return 0.5
+        case .buttonSmall: return 0.5
+        case .label: return 0.5
+        case .input: return 0
+        }
+    }
+
+    var relativeTo: Font.TextStyle {
+        switch self {
+        case .display1: return .largeTitle
+        case .display2: return .title
+        case .heading1: return .title2
+        case .heading2: return .title3
+        case .heading3: return .headline
+        case .bodyLarge: return .body
+        case .bodyRegular: return .body
+        case .bodyMedium: return .body
+        case .bodySemibold: return .body
+        case .bodySmall: return .callout
+        case .bodySmallMedium: return .callout
+        case .caption: return .caption
+        case .captionMedium: return .caption
+        case .buttonLarge: return .headline
+        case .buttonMedium: return .body
+        case .buttonSmall: return .callout
+        case .label: return .callout
+        case .input: return .body
+        }
+    }
+
+    var font: Font {
+        .system(size: size, weight: weight, design: .default)
+    }
+}
+
+struct TypographyModifier: ViewModifier {
+    let token: TypographyToken
+
+    @ScaledMetric private var scaledSize: CGFloat
+
+    init(token: TypographyToken) {
+        self.token = token
+        _scaledSize = ScaledMetric(wrappedValue: token.size, relativeTo: token.relativeTo)
+    }
+
+    func body(content: Content) -> some View {
+        content
+            .font(.system(size: scaledSize, weight: token.weight, design: .default))
+            .lineSpacing(token.lineSpacing)
+            .tracking(token.tracking)
+    }
+}

--- a/ios/AvaRoboticsTests/DesignSystem/ColorTokenTests.swift
+++ b/ios/AvaRoboticsTests/DesignSystem/ColorTokenTests.swift
@@ -1,0 +1,91 @@
+import XCTest
+import SwiftUI
+@testable import AvaRobotics
+
+final class ColorTokenTests: XCTestCase {
+
+    // MARK: - Helper
+
+    private func hexString(from color: Color) -> String {
+        let uiColor = UIColor(color)
+        var r: CGFloat = 0, g: CGFloat = 0, b: CGFloat = 0, a: CGFloat = 0
+        uiColor.getRed(&r, green: &g, blue: &b, alpha: &a)
+        return String(
+            format: "#%02x%02x%02x",
+            Int(round(r * 255)),
+            Int(round(g * 255)),
+            Int(round(b * 255))
+        )
+    }
+
+    // MARK: - Primary
+
+    func testPrimaryColors() {
+        XCTAssertEqual(hexString(from: ColorToken.Primary.p50), "#f5f3ff")
+        XCTAssertEqual(hexString(from: ColorToken.Primary.p100), "#ede9fe")
+        XCTAssertEqual(hexString(from: ColorToken.Primary.p200), "#ddd6fe")
+        XCTAssertEqual(hexString(from: ColorToken.Primary.p300), "#c4b5fd")
+        XCTAssertEqual(hexString(from: ColorToken.Primary.p400), "#a78bfa")
+        XCTAssertEqual(hexString(from: ColorToken.Primary.p500), "#8b5cf6")
+        XCTAssertEqual(hexString(from: ColorToken.Primary.p600), "#7c3aed")
+        XCTAssertEqual(hexString(from: ColorToken.Primary.p700), "#6d28d9")
+        XCTAssertEqual(hexString(from: ColorToken.Primary.p800), "#5b21b6")
+        XCTAssertEqual(hexString(from: ColorToken.Primary.p900), "#4c1d95")
+    }
+
+    // MARK: - Accent
+
+    func testAccentColors() {
+        XCTAssertEqual(hexString(from: ColorToken.Accent.a50), "#fdf4ff")
+        XCTAssertEqual(hexString(from: ColorToken.Accent.a100), "#fae8ff")
+        XCTAssertEqual(hexString(from: ColorToken.Accent.a200), "#f5d0fe")
+        XCTAssertEqual(hexString(from: ColorToken.Accent.a300), "#f0abfc")
+        XCTAssertEqual(hexString(from: ColorToken.Accent.a400), "#e879f9")
+        XCTAssertEqual(hexString(from: ColorToken.Accent.a500), "#d946ef")
+        XCTAssertEqual(hexString(from: ColorToken.Accent.a600), "#c026d3")
+        XCTAssertEqual(hexString(from: ColorToken.Accent.a700), "#a21caf")
+    }
+
+    // MARK: - Secondary
+
+    func testSecondaryColors() {
+        XCTAssertEqual(hexString(from: ColorToken.Secondary.s50), "#ecfeff")
+        XCTAssertEqual(hexString(from: ColorToken.Secondary.s100), "#cffafe")
+        XCTAssertEqual(hexString(from: ColorToken.Secondary.s200), "#a5f3fc")
+        XCTAssertEqual(hexString(from: ColorToken.Secondary.s300), "#67e8f9")
+        XCTAssertEqual(hexString(from: ColorToken.Secondary.s400), "#22d3ee")
+        XCTAssertEqual(hexString(from: ColorToken.Secondary.s500), "#06b6d4")
+        XCTAssertEqual(hexString(from: ColorToken.Secondary.s600), "#0891b2")
+    }
+
+    // MARK: - Neutral
+
+    func testNeutralColors() {
+        XCTAssertEqual(hexString(from: ColorToken.Neutral.n50), "#f8fafc")
+        XCTAssertEqual(hexString(from: ColorToken.Neutral.n100), "#f1f5f9")
+        XCTAssertEqual(hexString(from: ColorToken.Neutral.n200), "#e2e8f0")
+        XCTAssertEqual(hexString(from: ColorToken.Neutral.n300), "#cbd5e1")
+        XCTAssertEqual(hexString(from: ColorToken.Neutral.n400), "#94a3b8")
+        XCTAssertEqual(hexString(from: ColorToken.Neutral.n500), "#64748b")
+        XCTAssertEqual(hexString(from: ColorToken.Neutral.n600), "#475569")
+        XCTAssertEqual(hexString(from: ColorToken.Neutral.n700), "#334155")
+        XCTAssertEqual(hexString(from: ColorToken.Neutral.n800), "#1e293b")
+        XCTAssertEqual(hexString(from: ColorToken.Neutral.n900), "#0f172a")
+    }
+
+    // MARK: - Semantic
+
+    func testSemanticColors() {
+        XCTAssertEqual(hexString(from: ColorToken.Semantic.white), "#ffffff")
+        XCTAssertEqual(hexString(from: ColorToken.Semantic.black), "#000000")
+    }
+
+    // MARK: - Status
+
+    func testStatusColors() {
+        XCTAssertEqual(hexString(from: ColorToken.Status.success), "#22c55e")
+        XCTAssertEqual(hexString(from: ColorToken.Status.warning), "#f59e0b")
+        XCTAssertEqual(hexString(from: ColorToken.Status.error), "#ef4444")
+        XCTAssertEqual(hexString(from: ColorToken.Status.info), "#3b82f6")
+    }
+}

--- a/ios/AvaRoboticsTests/DesignSystem/GradientTokenTests.swift
+++ b/ios/AvaRoboticsTests/DesignSystem/GradientTokenTests.swift
@@ -1,0 +1,80 @@
+import XCTest
+import SwiftUI
+@testable import AvaRobotics
+
+final class GradientTokenTests: XCTestCase {
+
+    // MARK: - Helper
+
+    private func hexString(from color: Color) -> String {
+        let uiColor = UIColor(color)
+        var r: CGFloat = 0, g: CGFloat = 0, b: CGFloat = 0, a: CGFloat = 0
+        uiColor.getRed(&r, green: &g, blue: &b, alpha: &a)
+        return String(
+            format: "#%02x%02x%02x",
+            Int(round(r * 255)),
+            Int(round(g * 255)),
+            Int(round(b * 255))
+        )
+    }
+
+    // MARK: - Primary Gradient
+
+    func testPrimaryGradientStops() {
+        let stops = GradientToken.primaryStops
+        XCTAssertEqual(stops.count, 3)
+        XCTAssertEqual(hexString(from: stops[0]), "#8b5cf6")
+        XCTAssertEqual(hexString(from: stops[1]), "#6d28d9")
+        XCTAssertEqual(hexString(from: stops[2]), "#5b21b6")
+    }
+
+    // MARK: - Accent Gradient
+
+    func testAccentGradientStops() {
+        let stops = GradientToken.accentStops
+        XCTAssertEqual(stops.count, 3)
+        XCTAssertEqual(hexString(from: stops[0]), "#e879f9")
+        XCTAssertEqual(hexString(from: stops[1]), "#d946ef")
+        XCTAssertEqual(hexString(from: stops[2]), "#c026d3")
+    }
+
+    // MARK: - Secondary Gradient
+
+    func testSecondaryGradientStops() {
+        let stops = GradientToken.secondaryStops
+        XCTAssertEqual(stops.count, 3)
+        XCTAssertEqual(hexString(from: stops[0]), "#22d3ee")
+        XCTAssertEqual(hexString(from: stops[1]), "#06b6d4")
+        XCTAssertEqual(hexString(from: stops[2]), "#0891b2")
+    }
+
+    // MARK: - Neon Gradient
+
+    func testNeonGradientStops() {
+        let stops = GradientToken.neonStops
+        XCTAssertEqual(stops.count, 3)
+        XCTAssertEqual(hexString(from: stops[0]), "#8b5cf6")
+        XCTAssertEqual(hexString(from: stops[1]), "#d946ef")
+        XCTAssertEqual(hexString(from: stops[2]), "#22d3ee")
+    }
+
+    // MARK: - Tech Gradient
+
+    func testTechGradientStops() {
+        let stops = GradientToken.techStops
+        XCTAssertEqual(stops.count, 3)
+        XCTAssertEqual(hexString(from: stops[0]), "#6d28d9")
+        XCTAssertEqual(hexString(from: stops[1]), "#a21caf")
+        XCTAssertEqual(hexString(from: stops[2]), "#0891b2")
+    }
+
+    // MARK: - Background Gradient
+
+    func testBackgroundGradientStops() {
+        let stops = GradientToken.backgroundStops
+        XCTAssertEqual(stops.count, 3)
+        XCTAssertEqual(hexString(from: stops[0]), "#f5f3ff")
+        XCTAssertEqual(hexString(from: stops[1]), "#fdf4ff")
+        XCTAssertEqual(hexString(from: stops[2]), "#ecfeff")
+    }
+}

--- a/ios/AvaRoboticsTests/DesignSystem/ShadowTokenTests.swift
+++ b/ios/AvaRoboticsTests/DesignSystem/ShadowTokenTests.swift
@@ -1,0 +1,81 @@
+import XCTest
+import SwiftUI
+@testable import AvaRobotics
+
+final class ShadowTokenTests: XCTestCase {
+
+    // MARK: - Standard Shadows
+
+    func testSmShadow() {
+        let token = ShadowToken.sm
+        XCTAssertEqual(token.radius, 2)
+        XCTAssertEqual(token.x, 0)
+        XCTAssertEqual(token.y, 1)
+    }
+
+    func testMdShadow() {
+        let token = ShadowToken.md
+        XCTAssertEqual(token.radius, 6)
+        XCTAssertEqual(token.x, 0)
+        XCTAssertEqual(token.y, 4)
+    }
+
+    func testLgShadow() {
+        let token = ShadowToken.lg
+        XCTAssertEqual(token.radius, 15)
+        XCTAssertEqual(token.x, 0)
+        XCTAssertEqual(token.y, 10)
+    }
+
+    func testXlShadow() {
+        let token = ShadowToken.xl
+        XCTAssertEqual(token.radius, 25)
+        XCTAssertEqual(token.x, 0)
+        XCTAssertEqual(token.y, 20)
+    }
+
+    func testXxlShadow() {
+        let token = ShadowToken.xxl
+        XCTAssertEqual(token.radius, 50)
+        XCTAssertEqual(token.x, 0)
+        XCTAssertEqual(token.y, 25)
+    }
+
+    // MARK: - Glow Effects
+
+    func testGlowPurple() {
+        let token = ShadowToken.glowPurple
+        XCTAssertEqual(token.radius, 30)
+        XCTAssertEqual(token.x, 0)
+        XCTAssertEqual(token.y, 0)
+    }
+
+    func testGlowPink() {
+        let token = ShadowToken.glowPink
+        XCTAssertEqual(token.radius, 30)
+        XCTAssertEqual(token.x, 0)
+        XCTAssertEqual(token.y, 0)
+    }
+
+    func testGlowCyan() {
+        let token = ShadowToken.glowCyan
+        XCTAssertEqual(token.radius, 30)
+        XCTAssertEqual(token.x, 0)
+        XCTAssertEqual(token.y, 0)
+    }
+
+    // MARK: - Monotonically Increasing
+
+    func testShadowRadiusMonotonicallyIncreasing() {
+        let standardShadows: [ShadowToken] = [.sm, .md, .lg, .xl, .xxl]
+        for i in 0..<(standardShadows.count - 1) {
+            XCTAssertLessThan(standardShadows[i].radius, standardShadows[i + 1].radius)
+        }
+    }
+
+    // MARK: - All Cases Count
+
+    func testAllCasesCount() {
+        XCTAssertEqual(ShadowToken.allCases.count, 8)
+    }
+}

--- a/ios/AvaRoboticsTests/DesignSystem/ShapeTokenTests.swift
+++ b/ios/AvaRoboticsTests/DesignSystem/ShapeTokenTests.swift
@@ -1,0 +1,41 @@
+import XCTest
+@testable import AvaRobotics
+
+final class ShapeTokenTests: XCTestCase {
+
+    // MARK: - Corner Radius
+
+    func testCornerRadiusValues() {
+        XCTAssertEqual(ShapeToken.CornerRadius.none, 0)
+        XCTAssertEqual(ShapeToken.CornerRadius.sm, 6)
+        XCTAssertEqual(ShapeToken.CornerRadius.md, 8)
+        XCTAssertEqual(ShapeToken.CornerRadius.lg, 12)
+        XCTAssertEqual(ShapeToken.CornerRadius.xl, 16)
+        XCTAssertEqual(ShapeToken.CornerRadius.xxl, 24)
+        XCTAssertEqual(ShapeToken.CornerRadius.xxxl, 28)
+        XCTAssertEqual(ShapeToken.CornerRadius.full, 9999)
+    }
+
+    func testCornerRadiusMonotonicallyIncreasing() {
+        let values = [
+            ShapeToken.CornerRadius.none,
+            ShapeToken.CornerRadius.sm,
+            ShapeToken.CornerRadius.md,
+            ShapeToken.CornerRadius.lg,
+            ShapeToken.CornerRadius.xl,
+            ShapeToken.CornerRadius.xxl,
+            ShapeToken.CornerRadius.xxxl,
+            ShapeToken.CornerRadius.full
+        ]
+        for i in 0..<(values.count - 1) {
+            XCTAssertLessThan(values[i], values[i + 1])
+        }
+    }
+
+    // MARK: - Border Width
+
+    func testBorderWidthValues() {
+        XCTAssertEqual(ShapeToken.BorderWidth.thin, 1)
+        XCTAssertEqual(ShapeToken.BorderWidth.regular, 2)
+    }
+}

--- a/ios/AvaRoboticsTests/DesignSystem/SpacingTokenTests.swift
+++ b/ios/AvaRoboticsTests/DesignSystem/SpacingTokenTests.swift
@@ -1,0 +1,30 @@
+import XCTest
+@testable import AvaRobotics
+
+final class SpacingTokenTests: XCTestCase {
+
+    func testSpacingValues() {
+        XCTAssertEqual(SpacingToken.xs, 4)
+        XCTAssertEqual(SpacingToken.sm, 8)
+        XCTAssertEqual(SpacingToken.md, 16)
+        XCTAssertEqual(SpacingToken.lg, 24)
+        XCTAssertEqual(SpacingToken.xl, 32)
+        XCTAssertEqual(SpacingToken.xxl, 48)
+        XCTAssertEqual(SpacingToken.xxxl, 64)
+    }
+
+    func testMonotonicallyIncreasing() {
+        let values = [
+            SpacingToken.xs,
+            SpacingToken.sm,
+            SpacingToken.md,
+            SpacingToken.lg,
+            SpacingToken.xl,
+            SpacingToken.xxl,
+            SpacingToken.xxxl
+        ]
+        for i in 0..<(values.count - 1) {
+            XCTAssertLessThan(values[i], values[i + 1])
+        }
+    }
+}

--- a/ios/AvaRoboticsTests/DesignSystem/TypographyTokenTests.swift
+++ b/ios/AvaRoboticsTests/DesignSystem/TypographyTokenTests.swift
@@ -1,0 +1,197 @@
+import XCTest
+import SwiftUI
+@testable import AvaRobotics
+
+final class TypographyTokenTests: XCTestCase {
+
+    // MARK: - Display
+
+    func testDisplay1() {
+        let token = TypographyToken.display1
+        XCTAssertEqual(token.size, 36)
+        XCTAssertEqual(token.weight, .bold)
+        XCTAssertEqual(token.lineSpacing, 4)
+        XCTAssertEqual(token.tracking, -0.5)
+        XCTAssertEqual(token.relativeTo, .largeTitle)
+    }
+
+    func testDisplay2() {
+        let token = TypographyToken.display2
+        XCTAssertEqual(token.size, 30)
+        XCTAssertEqual(token.weight, .bold)
+        XCTAssertEqual(token.lineSpacing, 4)
+        XCTAssertEqual(token.tracking, -0.5)
+        XCTAssertEqual(token.relativeTo, .title)
+    }
+
+    // MARK: - Headings
+
+    func testHeading1() {
+        let token = TypographyToken.heading1
+        XCTAssertEqual(token.size, 24)
+        XCTAssertEqual(token.weight, .semibold)
+        XCTAssertEqual(token.lineSpacing, 2)
+        XCTAssertEqual(token.tracking, 0)
+        XCTAssertEqual(token.relativeTo, .title2)
+    }
+
+    func testHeading2() {
+        let token = TypographyToken.heading2
+        XCTAssertEqual(token.size, 20)
+        XCTAssertEqual(token.weight, .semibold)
+        XCTAssertEqual(token.lineSpacing, 2)
+        XCTAssertEqual(token.tracking, 0)
+        XCTAssertEqual(token.relativeTo, .title3)
+    }
+
+    func testHeading3() {
+        let token = TypographyToken.heading3
+        XCTAssertEqual(token.size, 18)
+        XCTAssertEqual(token.weight, .semibold)
+        XCTAssertEqual(token.lineSpacing, 2)
+        XCTAssertEqual(token.tracking, 0)
+        XCTAssertEqual(token.relativeTo, .headline)
+    }
+
+    // MARK: - Body
+
+    func testBodyLarge() {
+        let token = TypographyToken.bodyLarge
+        XCTAssertEqual(token.size, 18)
+        XCTAssertEqual(token.weight, .regular)
+        XCTAssertEqual(token.lineSpacing, 4)
+        XCTAssertEqual(token.tracking, 0)
+        XCTAssertEqual(token.relativeTo, .body)
+    }
+
+    func testBodyRegular() {
+        let token = TypographyToken.bodyRegular
+        XCTAssertEqual(token.size, 16)
+        XCTAssertEqual(token.weight, .regular)
+        XCTAssertEqual(token.lineSpacing, 4)
+        XCTAssertEqual(token.tracking, 0)
+        XCTAssertEqual(token.relativeTo, .body)
+    }
+
+    func testBodyMedium() {
+        let token = TypographyToken.bodyMedium
+        XCTAssertEqual(token.size, 16)
+        XCTAssertEqual(token.weight, .medium)
+        XCTAssertEqual(token.lineSpacing, 4)
+        XCTAssertEqual(token.tracking, 0)
+        XCTAssertEqual(token.relativeTo, .body)
+    }
+
+    func testBodySemibold() {
+        let token = TypographyToken.bodySemibold
+        XCTAssertEqual(token.size, 16)
+        XCTAssertEqual(token.weight, .semibold)
+        XCTAssertEqual(token.lineSpacing, 4)
+        XCTAssertEqual(token.tracking, 0)
+        XCTAssertEqual(token.relativeTo, .body)
+    }
+
+    func testBodySmall() {
+        let token = TypographyToken.bodySmall
+        XCTAssertEqual(token.size, 14)
+        XCTAssertEqual(token.weight, .regular)
+        XCTAssertEqual(token.lineSpacing, 3)
+        XCTAssertEqual(token.tracking, 0)
+        XCTAssertEqual(token.relativeTo, .callout)
+    }
+
+    func testBodySmallMedium() {
+        let token = TypographyToken.bodySmallMedium
+        XCTAssertEqual(token.size, 14)
+        XCTAssertEqual(token.weight, .medium)
+        XCTAssertEqual(token.lineSpacing, 3)
+        XCTAssertEqual(token.tracking, 0)
+        XCTAssertEqual(token.relativeTo, .callout)
+    }
+
+    // MARK: - Caption
+
+    func testCaption() {
+        let token = TypographyToken.caption
+        XCTAssertEqual(token.size, 12)
+        XCTAssertEqual(token.weight, .regular)
+        XCTAssertEqual(token.lineSpacing, 2)
+        XCTAssertEqual(token.tracking, 0)
+        XCTAssertEqual(token.relativeTo, .caption)
+    }
+
+    func testCaptionMedium() {
+        let token = TypographyToken.captionMedium
+        XCTAssertEqual(token.size, 12)
+        XCTAssertEqual(token.weight, .medium)
+        XCTAssertEqual(token.lineSpacing, 2)
+        XCTAssertEqual(token.tracking, 0)
+        XCTAssertEqual(token.relativeTo, .caption)
+    }
+
+    // MARK: - Button
+
+    func testButtonLarge() {
+        let token = TypographyToken.buttonLarge
+        XCTAssertEqual(token.size, 18)
+        XCTAssertEqual(token.weight, .semibold)
+        XCTAssertEqual(token.lineSpacing, 0)
+        XCTAssertEqual(token.tracking, 0.5)
+        XCTAssertEqual(token.relativeTo, .headline)
+    }
+
+    func testButtonMedium() {
+        let token = TypographyToken.buttonMedium
+        XCTAssertEqual(token.size, 16)
+        XCTAssertEqual(token.weight, .medium)
+        XCTAssertEqual(token.lineSpacing, 0)
+        XCTAssertEqual(token.tracking, 0.5)
+        XCTAssertEqual(token.relativeTo, .body)
+    }
+
+    func testButtonSmall() {
+        let token = TypographyToken.buttonSmall
+        XCTAssertEqual(token.size, 14)
+        XCTAssertEqual(token.weight, .medium)
+        XCTAssertEqual(token.lineSpacing, 0)
+        XCTAssertEqual(token.tracking, 0.5)
+        XCTAssertEqual(token.relativeTo, .callout)
+    }
+
+    // MARK: - Label & Input
+
+    func testLabel() {
+        let token = TypographyToken.label
+        XCTAssertEqual(token.size, 14)
+        XCTAssertEqual(token.weight, .medium)
+        XCTAssertEqual(token.lineSpacing, 0)
+        XCTAssertEqual(token.tracking, 0.5)
+        XCTAssertEqual(token.relativeTo, .callout)
+    }
+
+    func testInput() {
+        let token = TypographyToken.input
+        XCTAssertEqual(token.size, 16)
+        XCTAssertEqual(token.weight, .regular)
+        XCTAssertEqual(token.lineSpacing, 0)
+        XCTAssertEqual(token.tracking, 0)
+        XCTAssertEqual(token.relativeTo, .body)
+    }
+
+    // MARK: - Size Ordering
+
+    func testSizesDescendingWithinCategories() {
+        XCTAssertGreaterThan(TypographyToken.display1.size, TypographyToken.display2.size)
+        XCTAssertGreaterThan(TypographyToken.heading1.size, TypographyToken.heading2.size)
+        XCTAssertGreaterThanOrEqual(TypographyToken.heading2.size, TypographyToken.heading3.size)
+        XCTAssertGreaterThan(TypographyToken.bodyLarge.size, TypographyToken.bodyRegular.size)
+        XCTAssertGreaterThan(TypographyToken.bodyRegular.size, TypographyToken.bodySmall.size)
+        XCTAssertGreaterThan(TypographyToken.bodySmall.size, TypographyToken.caption.size)
+    }
+
+    // MARK: - All Cases Count
+
+    func testAllPresetsExist() {
+        XCTAssertEqual(TypographyToken.allCases.count, 18)
+    }
+}

--- a/specs/042-ios-design-tokens/checklists/requirements.md
+++ b/specs/042-ios-design-tokens/checklists/requirements.md
@@ -1,0 +1,36 @@
+# Specification Quality Checklist: iOS Design Tokens
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-02-08
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All items pass validation. The spec references Swift/SwiftUI in metadata context (as the target platform per user input) but does not prescribe implementation patterns, which is appropriate for a design token specification.
+- The spec intentionally includes specific hex values and point sizes because these ARE the requirements (the "what"), not implementation details (the "how").
+- Typography mentions SF Pro Display/SF Pro Text — these are platform-native fonts and part of the design requirement, not an implementation choice.

--- a/specs/042-ios-design-tokens/data-model.md
+++ b/specs/042-ios-design-tokens/data-model.md
@@ -1,0 +1,260 @@
+# Data Model: iOS Design Tokens
+
+Token entity definitions mapping web design values to Swift/SwiftUI constructs.
+
+## Table of Contents
+
+- [Color Palette Tokens](#color-palette-tokens)
+- [Typography Preset Tokens](#typography-preset-tokens)
+- [Spacing Tokens](#spacing-tokens)
+- [Shape Tokens](#shape-tokens)
+- [Shadow Tokens](#shadow-tokens)
+- [Gradient Tokens](#gradient-tokens)
+- [Opacity Tokens](#opacity-tokens)
+- [Component Tokens](#component-tokens)
+
+---
+
+## Color Palette Tokens
+
+### Primary (Tech Purple)
+
+| Token Name | Hex Value | Usage |
+|------------|-----------|-------|
+| `primary50` | #f5f3ff | Light background |
+| `primary100` | #ede9fe | — |
+| `primary200` | #ddd6fe | — |
+| `primary300` | #c4b5fd | — |
+| `primary400` | #a78bfa | — |
+| `primary500` | #8b5cf6 | Main brand color |
+| `primary600` | #7c3aed | — |
+| `primary700` | #6d28d9 | — |
+| `primary800` | #5b21b6 | — |
+| `primary900` | #4c1d95 | — |
+
+### Accent (Neon Pink)
+
+| Token Name | Hex Value | Usage |
+|------------|-----------|-------|
+| `accent50` | #fdf4ff | — |
+| `accent100` | #fae8ff | — |
+| `accent200` | #f5d0fe | — |
+| `accent300` | #f0abfc | — |
+| `accent400` | #e879f9 | Main accent |
+| `accent500` | #d946ef | — |
+| `accent600` | #c026d3 | — |
+| `accent700` | #a21caf | — |
+
+### Secondary (Electric Cyan)
+
+| Token Name | Hex Value | Usage |
+|------------|-----------|-------|
+| `secondary50` | #ecfeff | — |
+| `secondary100` | #cffafe | — |
+| `secondary200` | #a5f3fc | — |
+| `secondary300` | #67e8f9 | — |
+| `secondary400` | #22d3ee | Main cyan |
+| `secondary500` | #06b6d4 | — |
+| `secondary600` | #0891b2 | — |
+
+### Neutral (Grays)
+
+| Token Name | Hex Value | Usage |
+|------------|-----------|-------|
+| `neutral50` | #f8fafc | Light backgrounds |
+| `neutral100` | #f1f5f9 | Card backgrounds |
+| `neutral200` | #e2e8f0 | Borders |
+| `neutral300` | #cbd5e1 | Dividers |
+| `neutral400` | #94a3b8 | — |
+| `neutral500` | #64748b | — |
+| `neutral600` | #475569 | Secondary text |
+| `neutral700` | #334155 | Primary text |
+| `neutral800` | #1e293b | — |
+| `neutral900` | #0f172a | Dark text/backgrounds |
+
+### Semantic
+
+| Token Name | Hex Value |
+|------------|-----------|
+| `white` | #ffffff |
+| `black` | #000000 |
+
+### Status
+
+| Token Name | Hex Value | Usage |
+|------------|-----------|-------|
+| `success` | #22c55e | Success feedback |
+| `warning` | #f59e0b | Warning feedback |
+| `error` | #ef4444 | Error feedback |
+| `info` | #3b82f6 | Informational feedback |
+
+## Typography Preset Tokens
+
+Each preset maps to: font family (SF Pro via `.system()`), size (pt), weight, line spacing (pt), tracking (pt), and Dynamic Type `relativeTo` style.
+
+| Preset | Size | Weight | Line Spacing | Tracking | Relative To |
+|--------|------|--------|-------------|----------|-------------|
+| `display1` | 36 | bold | 4 | -0.5 | `.largeTitle` |
+| `display2` | 30 | bold | 4 | -0.5 | `.title` |
+| `heading1` | 24 | semibold | 2 | 0 | `.title2` |
+| `heading2` | 20 | semibold | 2 | 0 | `.title3` |
+| `heading3` | 18 | semibold | 2 | 0 | `.headline` |
+| `bodyLarge` | 18 | regular | 4 | 0 | `.body` |
+| `bodyRegular` | 16 | regular | 4 | 0 | `.body` |
+| `bodyMedium` | 16 | medium | 4 | 0 | `.body` |
+| `bodySemibold` | 16 | semibold | 4 | 0 | `.body` |
+| `bodySmall` | 14 | regular | 3 | 0 | `.callout` |
+| `bodySmallMedium` | 14 | medium | 3 | 0 | `.callout` |
+| `caption` | 12 | regular | 2 | 0 | `.caption` |
+| `captionMedium` | 12 | medium | 2 | 0 | `.caption` |
+| `buttonLarge` | 18 | semibold | 0 | 0.5 | `.headline` |
+| `buttonMedium` | 16 | medium | 0 | 0.5 | `.body` |
+| `buttonSmall` | 14 | medium | 0 | 0.5 | `.callout` |
+| `label` | 14 | medium | 0 | 0.5 | `.callout` |
+| `input` | 16 | regular | 0 | 0 | `.body` |
+
+## Spacing Tokens
+
+| Token | Value (pt) | Web Equivalent |
+|-------|-----------|----------------|
+| `xs` | 4 | 0.25rem |
+| `sm` | 8 | 0.5rem |
+| `md` | 16 | 1rem |
+| `lg` | 24 | 1.5rem |
+| `xl` | 32 | 2rem |
+| `xxl` | 48 | 3rem |
+| `xxxl` | 64 | 4rem |
+
+## Shape Tokens
+
+### Corner Radius
+
+| Token | Value (pt) | Usage |
+|-------|-----------|-------|
+| `none` | 0 | No rounding |
+| `sm` | 6 | Small elements |
+| `md` | 8 | Input fields |
+| `lg` | 12 | Small cards |
+| `xl` | 16 | Medium cards |
+| `xxl` | 24 | Large cards |
+| `xxxl` | 28 | iOS icon standard |
+| `full` | 9999 | Pill/capsule (buttons, avatars) |
+
+### Border Width
+
+| Token | Value (pt) |
+|-------|-----------|
+| `thin` | 1 |
+| `regular` | 2 |
+
+## Shadow Tokens
+
+### Standard Shadows
+
+| Token | X | Y | Blur | Spread Color |
+|-------|---|---|------|-------------|
+| `sm` | 0 | 1 | 2 | rgba(0, 0, 0, 0.05) |
+| `md` | 0 | 4 | 6 | rgba(0, 0, 0, 0.1) |
+| `lg` | 0 | 10 | 15 | rgba(0, 0, 0, 0.1) |
+| `xl` | 0 | 20 | 25 | rgba(0, 0, 0, 0.1) |
+| `xxl` | 0 | 25 | 50 | rgba(0, 0, 0, 0.25) |
+
+### Glow Effects
+
+| Token | X | Y | Blur | Color |
+|-------|---|---|------|-------|
+| `glowPurple` | 0 | 0 | 30 | rgba(139, 92, 246, 0.5) |
+| `glowPink` | 0 | 0 | 30 | rgba(217, 70, 239, 0.5) |
+| `glowCyan` | 0 | 0 | 30 | rgba(34, 211, 238, 0.5) |
+
+## Gradient Tokens
+
+All gradients are linear at 135 degrees (`.topLeading` → `.bottomTrailing` in SwiftUI).
+
+| Token | Stop 1 | Stop 2 | Stop 3 |
+|-------|--------|--------|--------|
+| `primary` | #8b5cf6 (0%) | #6d28d9 (50%) | #5b21b6 (100%) |
+| `accent` | #e879f9 (0%) | #d946ef (50%) | #c026d3 (100%) |
+| `secondary` | #22d3ee (0%) | #06b6d4 (50%) | #0891b2 (100%) |
+| `neon` | #8b5cf6 (0%) | #d946ef (50%) | #22d3ee (100%) |
+| `tech` | #6d28d9 (0%) | #a21caf (50%) | #0891b2 (100%) |
+| `background` | #f5f3ff (0%) | #fdf4ff (50%) | #ecfeff (100%) |
+
+## Opacity Tokens
+
+| Token | Value |
+|-------|-------|
+| `opacity5` | 0.05 |
+| `opacity10` | 0.10 |
+| `opacity20` | 0.20 |
+| `opacity30` | 0.30 |
+| `opacity40` | 0.40 |
+| `opacity50` | 0.50 |
+| `opacity60` | 0.60 |
+| `opacity70` | 0.70 |
+| `opacity80` | 0.80 |
+| `opacity90` | 0.90 |
+| `opacity100` | 1.00 |
+
+## Component Tokens
+
+### Button — Primary
+
+| Property | Token Reference |
+|----------|----------------|
+| Background | `GradientToken.primary` |
+| Text color | `ColorToken.Semantic.white` |
+| Text style | `TypographyToken.buttonMedium` |
+| Corner radius | `ShapeToken.CornerRadius.full` |
+| Shadow | `ShadowToken.md` |
+| Padding H | `SpacingToken.lg` (24pt) |
+| Padding V | `SpacingToken.md` (16pt) |
+
+### Button — Secondary
+
+| Property | Token Reference |
+|----------|----------------|
+| Background | `GradientToken.accent` |
+| Text color | `ColorToken.Semantic.white` |
+| Text style | `TypographyToken.buttonMedium` |
+| Corner radius | `ShapeToken.CornerRadius.full` |
+| Shadow | `ShadowToken.md` |
+| Padding H | `SpacingToken.lg` (24pt) |
+| Padding V | `SpacingToken.md` (16pt) |
+
+### Button — Outline
+
+| Property | Token Reference |
+|----------|----------------|
+| Background | Transparent |
+| Border color | `ColorToken.Primary.p500` |
+| Border width | `ShapeToken.BorderWidth.regular` (2pt) |
+| Text color | `ColorToken.Primary.p500` |
+| Text style | `TypographyToken.buttonMedium` |
+| Corner radius | `ShapeToken.CornerRadius.full` |
+| Padding H | `SpacingToken.lg` (24pt) |
+| Padding V | `SpacingToken.md` (16pt) |
+
+### Card — Standard
+
+| Property | Token Reference |
+|----------|----------------|
+| Background | `ColorToken.Semantic.white` |
+| Corner radius | `ShapeToken.CornerRadius.xxl` (24pt) |
+| Shadow | `ShadowToken.lg` |
+| Padding (small) | `SpacingToken.md` (16pt) |
+| Padding (medium) | `SpacingToken.lg` (24pt) |
+| Padding (large) | `SpacingToken.xl` (32pt) |
+
+### Input Field
+
+| Property | Token Reference |
+|----------|----------------|
+| Text style | `TypographyToken.input` |
+| Padding V | 12pt |
+| Padding H | `SpacingToken.md` (16pt) |
+| Corner radius | `ShapeToken.CornerRadius.lg` (12pt) |
+| Border width | `ShapeToken.BorderWidth.regular` (2pt) |
+| Border — default | `ColorToken.Neutral.n200` |
+| Border — focus | `ColorToken.Primary.p500` |
+| Border — error | `ColorToken.Status.error` |

--- a/specs/042-ios-design-tokens/plan.md
+++ b/specs/042-ios-design-tokens/plan.md
@@ -1,0 +1,93 @@
+# Implementation Plan: iOS Design Tokens
+
+Implement a compile-time-safe SwiftUI design token system using enum-based token definitions with ViewModifiers, mirroring the web app's design language from `figma-design-tokens.json`.
+
+## Table of Contents
+
+- [Summary](#summary)
+- [Technical Context](#technical-context)
+- [Constitution Check](#constitution-check)
+- [Project Structure](#project-structure)
+- [Complexity Tracking](#complexity-tracking)
+
+---
+
+**Branch**: `042-ios-design-tokens` | **Date**: 2026-02-08 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/042-ios-design-tokens/spec.md`
+
+## Summary
+
+Build a centralized design token system for the iOS app that mirrors the web application's Figma design tokens. The system uses Swift enums with static properties for primitive tokens (colors, spacing, shapes) and enum cases with computed properties for composite tokens (typography, shadows). SwiftUI ViewModifiers provide ergonomic application of typography and shadow tokens. Component-level tokens are implemented via SwiftUI's native style protocols (`ButtonStyle`, `TextFieldStyle`) and custom ViewModifiers. All tokens are resolved at compile time. Typography supports Dynamic Type via `@ScaledMetric`.
+
+## Technical Context
+
+**Language/Version**: Swift 5.9+
+**Primary Dependencies**: SwiftUI (system framework), XCTest (system framework) — no third-party dependencies
+**Storage**: N/A
+**Testing**: XCTest — unit tests validating token values against web spec hex/pt values
+**Target Platform**: iOS 15+
+**Project Type**: Mobile (iOS only — design tokens module within existing app structure)
+**Performance Goals**: N/A (design tokens are static constants with zero runtime overhead)
+**Constraints**: All token references must resolve at compile time; typography must support Dynamic Type
+**Scale/Scope**: ~37 color shades + 4 status colors, 17 typography presets, 7 spacing levels, 8 border radii, 5 shadows + 3 glows, 6 gradients, 3 component styles
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+Constitution is an unpopulated template — no custom principles defined. No gates to check. Proceeding.
+
+**Post-Phase 1 re-check**: Design uses only Swift enums, static properties, ViewModifiers, and SwiftUI style protocols. No external dependencies, no complex architecture patterns. No violations.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/042-ios-design-tokens/
+├── plan.md              # This file
+├── research.md          # Phase 0: SwiftUI design token patterns research
+├── data-model.md        # Phase 1: Token entity definitions
+├── quickstart.md        # Phase 1: Developer quickstart guide
+└── tasks.md             # Phase 2 output (/speckit.tasks command)
+```
+
+### Source Code (repository root)
+
+```text
+ios/AvaRobotics/
+├── DesignSystem/
+│   ├── Tokens/
+│   │   ├── ColorToken.swift           # Color palettes (primary, accent, secondary, neutral, semantic, status)
+│   │   ├── TypographyToken.swift      # Typography presets + TypographyModifier
+│   │   ├── SpacingToken.swift         # Spacing scale (xs through 3xl)
+│   │   ├── ShapeToken.swift           # Border radius + border width tokens
+│   │   ├── ShadowToken.swift          # Shadow levels + glow effects + ShadowModifier
+│   │   ├── GradientToken.swift        # Gradient presets (primary, accent, secondary, neon, tech, background)
+│   │   └── OpacityToken.swift         # Opacity scale (5% through 100%)
+│   ├── Components/
+│   │   ├── ButtonStyles.swift         # PrimaryButtonStyle, SecondaryButtonStyle, OutlineButtonStyle
+│   │   ├── CardModifier.swift         # CardModifier + .cardStyle() convenience
+│   │   └── TextFieldStyles.swift      # BrandedTextFieldStyle with focus/error states
+│   └── Extensions/
+│       ├── Color+Hex.swift            # Color(hex:) initializer utility
+│       └── View+DesignSystem.swift    # .typography(), .shadow() View extensions
+├── AvaRoboticsTests/
+│   └── DesignSystem/
+│       ├── ColorTokenTests.swift      # Verify hex values match web spec
+│       ├── TypographyTokenTests.swift # Verify preset configurations
+│       ├── SpacingTokenTests.swift    # Verify spacing scale values
+│       ├── ShapeTokenTests.swift      # Verify border radius values
+│       ├── ShadowTokenTests.swift     # Verify shadow configurations
+│       └── GradientTokenTests.swift   # Verify gradient color stops
+```
+
+**Structure Decision**: Mobile (iOS) structure. Design tokens live in a dedicated `DesignSystem/` directory within the existing `ios/AvaRobotics/` project structure defined in `ios/CLAUDE.md`. The `DesignSystem/` directory is organized into `Tokens/` (primitive values), `Components/` (composed styles), and `Extensions/` (utilities). This keeps design tokens separate from business logic while remaining part of the main app target. No API endpoints — contracts directory is not applicable.
+
+## Complexity Tracking
+
+No violations to justify. The design uses only:
+- Swift enums with static properties (simplest possible constant definition)
+- SwiftUI ViewModifiers (standard pattern for reusable styling)
+- SwiftUI style protocols (ButtonStyle, TextFieldStyle — framework-native patterns)
+- XCTest assertions (standard unit testing)

--- a/specs/042-ios-design-tokens/quickstart.md
+++ b/specs/042-ios-design-tokens/quickstart.md
@@ -1,0 +1,225 @@
+# Quickstart: iOS Design Tokens
+
+Get started using the Ava Robotics design token system in your SwiftUI views.
+
+## Table of Contents
+
+- [Colors](#colors)
+- [Typography](#typography)
+- [Spacing](#spacing)
+- [Shapes](#shapes)
+- [Shadows](#shadows)
+- [Gradients](#gradients)
+- [Opacity](#opacity)
+- [Components](#components)
+
+---
+
+## Colors
+
+All colors are accessed via `ColorToken` with nested enums for each palette.
+
+```swift
+// Brand colors
+Text("Hello")
+    .foregroundStyle(ColorToken.Primary.p500)    // Tech Purple
+
+// Accent
+Circle()
+    .fill(ColorToken.Accent.a400)               // Neon Pink
+
+// Secondary
+Rectangle()
+    .fill(ColorToken.Secondary.s400)             // Electric Cyan
+
+// Neutral (text, backgrounds, borders)
+Text("Subtitle")
+    .foregroundStyle(ColorToken.Neutral.n600)     // Secondary text
+VStack { }
+    .background(ColorToken.Neutral.n50)           // Light background
+
+// Semantic
+Text("Label")
+    .foregroundStyle(ColorToken.Semantic.white)
+
+// Status
+Text("Saved!")
+    .foregroundStyle(ColorToken.Status.success)   // Green
+Text("Error occurred")
+    .foregroundStyle(ColorToken.Status.error)     // Red
+```
+
+## Typography
+
+Apply typography presets with the `.typography()` modifier. All presets support Dynamic Type automatically.
+
+```swift
+// Titles
+Text("Welcome Back")
+    .typography(.display1)
+
+Text("Section Title")
+    .typography(.heading1)
+
+// Body text
+Text("Regular body content.")
+    .typography(.bodyRegular)
+
+Text("Emphasized body content.")
+    .typography(.bodyMedium)
+
+// Small text
+Text("Helper text")
+    .typography(.caption)
+
+// Buttons
+Text("SIGN IN")
+    .typography(.buttonMedium)
+
+// Form labels
+Text("Email Address")
+    .typography(.label)
+```
+
+## Spacing
+
+Use `SpacingToken` constants for padding, margins, and gaps.
+
+```swift
+VStack(spacing: SpacingToken.md) {          // 16pt gap between items
+    Text("Title")
+    Text("Subtitle")
+}
+.padding(.horizontal, SpacingToken.lg)      // 24pt horizontal padding
+.padding(.vertical, SpacingToken.xl)        // 32pt vertical padding
+
+// Available values:
+// SpacingToken.xs   =  4pt
+// SpacingToken.sm   =  8pt
+// SpacingToken.md   = 16pt
+// SpacingToken.lg   = 24pt
+// SpacingToken.xl   = 32pt
+// SpacingToken.xxl  = 48pt
+// SpacingToken.xxxl = 64pt
+```
+
+## Shapes
+
+Use `ShapeToken.CornerRadius` for border radius and `ShapeToken.BorderWidth` for borders.
+
+```swift
+// Rounded card
+RoundedRectangle(cornerRadius: ShapeToken.CornerRadius.xxl)
+    .fill(ColorToken.Semantic.white)
+
+// Pill shape (buttons, tags)
+Capsule()  // or use ShapeToken.CornerRadius.full
+    .fill(ColorToken.Primary.p500)
+
+// Bordered input
+RoundedRectangle(cornerRadius: ShapeToken.CornerRadius.lg)
+    .strokeBorder(ColorToken.Neutral.n200, lineWidth: ShapeToken.BorderWidth.regular)
+```
+
+## Shadows
+
+Apply shadows with the `.tokenShadow()` modifier.
+
+```swift
+// Standard shadows
+CardView()
+    .tokenShadow(.lg)                          // Standard card shadow
+
+// Glow effects
+FeatureIcon()
+    .tokenShadow(.glowPurple)                  // Purple neon glow
+
+// Available levels: .sm, .md, .lg, .xl, .xxl
+// Glow effects: .glowPurple, .glowPink, .glowCyan
+```
+
+## Gradients
+
+Use `GradientToken` for predefined linear gradients.
+
+```swift
+// Primary gradient background
+RoundedRectangle(cornerRadius: ShapeToken.CornerRadius.xxl)
+    .fill(GradientToken.primary)
+
+// Neon gradient (purple → pink → cyan)
+Text("Featured")
+    .padding()
+    .background(GradientToken.neon)
+
+// Subtle background gradient
+ZStack { }
+    .background(GradientToken.background)
+
+// Available: .primary, .accent, .secondary, .neon, .tech, .background
+```
+
+## Opacity
+
+Apply opacity to any color using `OpacityToken`.
+
+```swift
+// Semi-transparent overlay
+Rectangle()
+    .fill(ColorToken.Semantic.black.opacity(OpacityToken.opacity50))
+
+// Subtle background tint
+VStack { }
+    .background(ColorToken.Primary.p500.opacity(OpacityToken.opacity10))
+```
+
+## Components
+
+### Buttons
+
+Use SwiftUI's `.buttonStyle()` with predefined styles.
+
+```swift
+// Primary button (gradient background, white text, pill shape)
+Button("Get Started") { }
+    .buttonStyle(.brandPrimary)
+
+// Secondary button (accent gradient)
+Button("Learn More") { }
+    .buttonStyle(.brandSecondary)
+
+// Outline button (bordered, transparent)
+Button("Cancel") { }
+    .buttonStyle(.brandOutline)
+```
+
+### Cards
+
+Use the `.cardStyle()` modifier.
+
+```swift
+// Standard card (white bg, 24pt radius, lg shadow, 24pt padding)
+VStack {
+    Text("Robot Status")
+        .typography(.heading2)
+    Text("All systems operational")
+        .typography(.bodyRegular)
+        .foregroundStyle(ColorToken.Neutral.n600)
+}
+.cardStyle()
+
+// Card with custom padding
+VStack { ... }
+    .cardStyle(padding: .small)     // 16pt padding
+    .cardStyle(padding: .large)     // 32pt padding
+```
+
+### Text Fields
+
+Use `.textFieldStyle(.branded)` for styled inputs.
+
+```swift
+// Standard text field (with focus/error border states)
+TextField("Email", text: $email)
+    .textFieldStyle(.branded)
+```

--- a/specs/042-ios-design-tokens/research.md
+++ b/specs/042-ios-design-tokens/research.md
@@ -1,0 +1,157 @@
+# Research: iOS Design Tokens
+
+Summary of technology decisions and best practices for implementing SwiftUI design tokens.
+
+## Table of Contents
+
+- [Color Token Pattern](#color-token-pattern)
+- [Typography Token Pattern](#typography-token-pattern)
+- [Spacing Token Pattern](#spacing-token-pattern)
+- [Shape and Shadow Token Pattern](#shape-and-shadow-token-pattern)
+- [Gradient Token Pattern](#gradient-token-pattern)
+- [Component Token Pattern](#component-token-pattern)
+- [File Organization](#file-organization)
+- [Testing Strategy](#testing-strategy)
+- [Dynamic Type Support](#dynamic-type-support)
+- [Dark Mode Architecture](#dark-mode-architecture)
+
+---
+
+## Color Token Pattern
+
+**Decision**: Swift enum with static `Color` properties using hex initializer
+
+**Rationale**:
+- Provides compile-time safety — referencing a non-existent color produces a compile error
+- Enum namespacing groups colors by palette (e.g., `ColorToken.Primary.p500`)
+- Hex initializer allows direct mapping from web `figma-design-tokens.json` values
+- No Asset Catalog dependency keeps the system self-contained in Swift source files
+- Future dark mode can be added by wrapping hex values in `Color(UIColor { traitCollection in ... })` without changing the public API
+
+**Alternatives considered**:
+- Asset Catalog colors: Provide native dark mode toggle and visual Xcode editor, but add a non-code dependency. Color names are stringly-typed unless using Xcode 15+ generated accessors. Rejected because the project prioritizes source-code-as-truth and cross-referencing with `figma-design-tokens.json`.
+- Raw `Color` extensions (e.g., `Color.brandPrimary`): Simple but pollutes the `Color` namespace and lacks grouping. Rejected for discoverability reasons.
+
+## Typography Token Pattern
+
+**Decision**: Enum cases with computed properties for font, size, weight, lineSpacing, and tracking + ViewModifier with `@ScaledMetric` for Dynamic Type
+
+**Rationale**:
+- Enum cases model the finite set of 17 typography presets as discrete values
+- Computed properties return the correct `Font`, `CGFloat` values per preset
+- `@ScaledMetric(relativeTo:)` in the ViewModifier ensures proportional scaling with Dynamic Type
+- Single `.typography(.headingOne)` call site keeps views clean
+- SF Pro Display/Text are automatically selected by SwiftUI's `.system(size:weight:design:)` based on point size (Display for 20pt+, Text for below)
+
+**Alternatives considered**:
+- Font extensions (e.g., `Font.heading1`): Simple but cannot encapsulate line spacing and tracking. Rejected because typography presets require multiple properties.
+- Struct-based tokens: More flexible but enum cases provide exhaustive switch coverage and clearer intent. Rejected as over-engineering for a fixed set of presets.
+
+## Spacing Token Pattern
+
+**Decision**: Enum with static `CGFloat` properties
+
+**Rationale**:
+- Static properties give zero-boilerplate usage: `SpacingToken.md` returns `CGFloat` directly
+- No `.rawValue` needed at call sites (unlike `enum: CGFloat`)
+- Matches the web's 7-level scale exactly: xs (4), sm (8), md (16), lg (24), xl (32), xxl (48), xxxl (64)
+
+**Alternatives considered**:
+- `enum SpacingToken: CGFloat` with rawValue: Requires `.rawValue` at every call site. Rejected for verbosity.
+- Dedicated struct: Over-engineering for simple constants. Rejected.
+
+## Shape and Shadow Token Pattern
+
+**Decision**: Nested enums for corner radius/border width; enum cases with computed properties for shadows
+
+**Rationale**:
+- Corner radius and border width are simple constants — static properties in nested enums (e.g., `ShapeToken.CornerRadius.lg`)
+- Shadows have multiple dimensions (radius, x, y, color) — enum cases with computed properties model this cleanly
+- Glow effects are additional shadow enum cases with different color/radius configurations
+- A `ShadowModifier` ViewModifier wraps `View.shadow(color:radius:x:y:)` for ergonomic usage
+
+**Alternatives considered**:
+- Struct-based shadow definitions: More flexible but enum cases are sufficient for a fixed set of 5 shadows + 3 glows. Rejected.
+
+## Gradient Token Pattern
+
+**Decision**: Enum with static `LinearGradient` properties, composed from token colors
+
+**Rationale**:
+- All web gradients are linear at 135 degrees — `LinearGradient` with `.topLeading` → `.bottomTrailing` maps directly
+- Static properties return ready-to-use `LinearGradient` values (no assembly at call site)
+- Gradient color stops reference `ColorToken` values, maintaining single source of truth
+
+**Alternatives considered**:
+- Separate `Gradient.Stop` arrays: More flexible for reuse across gradient types (linear/radial/angular), but only linear gradients are defined in the web spec. Rejected as YAGNI.
+
+## Component Token Pattern
+
+**Decision**: SwiftUI style protocols (`ButtonStyle`, `TextFieldStyle`) for system views; custom `ViewModifier` for cards
+
+**Rationale**:
+- SwiftUI provides native style protocols for buttons and text fields — using them enables `.buttonStyle(.primary)` syntax
+- Cards have no system style protocol — a `ViewModifier` with `.cardStyle()` convenience is the standard pattern
+- Component styles compose primitive tokens (colors, spacing, shapes, shadows) rather than defining raw values
+- Pressed/focused states are handled within the style protocol's `makeBody(configuration:)` method
+
+**Alternatives considered**:
+- Custom wrapper views (e.g., `BrandButton`): Hides SwiftUI's native `Button` API surface. Rejected to preserve framework idioms.
+- ViewModifier for everything: Would lose SwiftUI's style cascade behavior for buttons/text fields. Rejected.
+
+## File Organization
+
+**Decision**: `DesignSystem/` directory with `Tokens/`, `Components/`, `Extensions/` subdirectories
+
+**Rationale**:
+- Dedicated top-level directory signals this is the single source of truth for all visual decisions
+- `Tokens/` holds primitive values (one file per token category)
+- `Components/` holds composed styles (ButtonStyles, CardModifier, TextFieldStyles)
+- `Extensions/` holds utilities (Color+Hex, View+DesignSystem convenience methods)
+- Maps cleanly to a future Swift Package extraction if needed
+- Aligns with existing project structure from `ios/CLAUDE.md`
+
+**Alternatives considered**:
+- `Theme/` directory: Implies only colors and appearance toggling, not a full design system. Rejected.
+- Flat file structure: All tokens in one file. Rejected for maintainability at 37+ colors, 17 typography presets, etc.
+
+## Testing Strategy
+
+**Decision**: XCTest unit tests validating raw token values against web spec
+
+**Rationale**:
+- Color tests resolve `Color` → `UIColor` → RGBA components → hex string, then assert against spec hex values
+- Spacing/shape tests assert `CGFloat` values directly against spec point values
+- Typography tests verify size, weight, line spacing, and tracking per preset
+- Shadow tests verify radius, offset, and color configurations
+- Tests serve as a contract between the design spec and the code implementation
+
+**Alternatives considered**:
+- Snapshot testing: Useful for visual regression but requires infrastructure (reference images, CI rendering). Deferred — can be added later as a complement.
+- No tests: Rejected because token values are the entire deliverable and must be verified against the web spec.
+
+## Dynamic Type Support
+
+**Decision**: `@ScaledMetric(relativeTo:)` in `TypographyModifier` for proportional font scaling
+
+**Rationale**:
+- `@ScaledMetric` property wrapper scales the base point size proportionally to the user's Dynamic Type setting
+- The `relativeTo` parameter maps each typography preset to the nearest Apple semantic text style (e.g., heading-1 → `.title2`), ensuring consistent scaling behavior
+- SwiftUI's `.system(size:weight:design:)` does NOT scale with Dynamic Type on its own — `@ScaledMetric` is required
+
+**Alternatives considered**:
+- Apple semantic text styles only (e.g., `.title`, `.body`): Would lose the exact point sizes from the web spec. Rejected because the spec requires precise size matching.
+- No Dynamic Type support: Violates FR-009. Rejected.
+
+## Dark Mode Architecture
+
+**Decision**: Structure tokens to support future dark mode without current implementation
+
+**Rationale**:
+- The enum-based color token pattern can be extended by replacing `Color(hex:)` with `Color(UIColor { traitCollection in ... })` to return different hex values per appearance
+- This change is internal to `ColorToken.swift` — consuming views reference `ColorToken.Primary.p500` regardless of whether it returns a fixed or adaptive color
+- No architectural restructuring needed when dark mode values are later defined
+- FR-010 requires the architecture to support this, not that dark mode values exist now
+
+**Alternatives considered**:
+- Asset Catalog from the start: Would provide dark mode toggle natively but introduces non-source dependency. Can be migrated to later if needed. Rejected for initial implementation simplicity.

--- a/specs/042-ios-design-tokens/spec.md
+++ b/specs/042-ios-design-tokens/spec.md
@@ -1,0 +1,211 @@
+# Feature Specification: iOS Design Tokens
+
+Establish a centralized design token system for the iOS app (Swift/SwiftUI) that mirrors the web application's design language, ensuring visual consistency across platforms.
+
+## Table of Contents
+
+- [Clarifications](#clarifications)
+- [User Scenarios & Testing](#user-scenarios--testing-mandatory)
+- [Requirements](#requirements-mandatory)
+- [Success Criteria](#success-criteria-mandatory)
+
+---
+
+**Feature Branch**: `042-ios-design-tokens`
+**Created**: 2026-02-08
+**Status**: Draft
+**Input**: User description: "Build iOS design tokens based on web app design system for Swift/SwiftUI"
+
+## Clarifications
+
+### Session 2026-02-08
+
+- Q: Should the design token system include semantic status colors (success, warning, error, info) beyond the single error red (#ef4444) defined in the web tokens? → A: Yes, include the full standard set: success (#22c55e green), warning (#f59e0b amber), error (#ef4444 red), info (#3b82f6 blue)
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Consistent Brand Colors Across Platforms (Priority: P1)
+
+As a developer building the iOS app, I need a single source of truth for all brand colors so that the iOS app visually matches the web application without manually copying hex values into each view.
+
+The web app defines the following color palettes that must be available on iOS:
+- **Primary (Tech Purple)**: 10-shade scale from #f5f3ff (50) to #4c1d95 (900), with #8b5cf6 (500) as the main brand color
+- **Accent (Neon Pink)**: 7-shade scale from #fdf4ff (50) to #a21caf (700), with #e879f9 (400) as the main accent
+- **Secondary (Electric Cyan)**: 6-shade scale from #ecfeff (50) to #0891b2 (600), with #22d3ee (400) as the main cyan
+- **Neutral (Grays)**: 10-shade scale from #f8fafc (50) to #0f172a (900)
+- **Semantic**: White (#ffffff) and Black (#000000)
+- **Status Colors**: Success (#22c55e green), Warning (#f59e0b amber), Error (#ef4444 red), Info (#3b82f6 blue) — for validation feedback, alerts, banners, and toast messages
+
+**Why this priority**: Colors are the most visible element of brand consistency. Without a shared color system, every screen built will diverge from the web design.
+
+**Independent Test**: Can be fully tested by creating a color swatch preview screen that renders every color token side-by-side with the web hex values and verifying they match exactly.
+
+**Acceptance Scenarios**:
+
+1. **Given** the iOS design token package is integrated, **When** a developer references the primary brand color, **Then** the rendered color matches #8b5cf6 exactly
+2. **Given** the iOS design token package is integrated, **When** a developer uses any color from the primary, accent, secondary, or neutral palette, **Then** every shade matches its corresponding web hex value
+3. **Given** both web and iOS apps are displayed side by side, **When** comparing identical UI elements, **Then** the colors are visually indistinguishable
+4. **Given** the iOS design token package is integrated, **When** a developer references a status color (success, warning, error, info), **Then** the rendered color matches the defined hex value (#22c55e, #f59e0b, #ef4444, #3b82f6 respectively)
+
+---
+
+### User Story 2 - Consistent Typography System (Priority: P1)
+
+As a developer, I need predefined typography styles (font families, sizes, weights, line heights, letter spacing) so that text rendering on iOS matches the web app's type hierarchy without manual configuration per view.
+
+The web app defines:
+- **Font Families**: SF Pro Display (titles), SF Pro Text (body) — these are native iOS system fonts
+- **Font Sizes**: xs (12px), sm (14px), base (16px), lg (18px), xl (20px), 2xl (24px), 3xl (30px), 4xl (36px)
+- **Font Weights**: normal (400), medium (500), semibold (600), bold (700)
+- **Line Heights**: tight (1.2), normal (1.5), relaxed (1.75)
+- **Letter Spacing**: tight (-0.5px), normal (0px), wide (0.5px)
+- **Typography Presets**: display-1, display-2, heading-1/2/3, body-large/regular/medium/semibold/small, caption, button-large/medium/small, label, input
+
+**Why this priority**: Typography defines the reading experience. Inconsistent type styles create a disjointed feel between platforms.
+
+**Independent Test**: Can be fully tested by rendering a type specimen screen showing all typography presets and comparing against the web app's rendered output.
+
+**Acceptance Scenarios**:
+
+1. **Given** the typography tokens are available, **When** a developer applies the "heading-1" preset, **Then** it renders at 24pt, semibold weight, with tight line height (1.2)
+2. **Given** the typography tokens are available, **When** a developer applies the "body-regular" preset, **Then** it renders at 16pt, regular weight, with normal line height (1.5)
+3. **Given** a list of all typography presets, **When** each is rendered on iOS, **Then** every preset matches the corresponding web definition
+
+---
+
+### User Story 3 - Spacing and Layout Tokens (Priority: P2)
+
+As a developer, I need a standardized spacing scale so that padding, margins, and gaps between elements are consistent with the web app's layout rhythm.
+
+The web app defines:
+- **Spacing Scale**: xs (4pt), sm (8pt), md (16pt), lg (24pt), xl (32pt), 2xl (48pt), 3xl (64pt)
+
+**Why this priority**: Spacing consistency is critical for a polished look but is less immediately noticeable than color or typography mismatches.
+
+**Independent Test**: Can be fully tested by creating a layout demo screen that shows each spacing token as visible gaps between elements and verifying measurements.
+
+**Acceptance Scenarios**:
+
+1. **Given** the spacing tokens are available, **When** a developer uses the "md" spacing value, **Then** it renders as exactly 16 points of space
+2. **Given** the spacing tokens are available, **When** all seven spacing values are applied, **Then** each matches the defined scale (4, 8, 16, 24, 32, 48, 64 points)
+
+---
+
+### User Story 4 - Shape and Shadow Tokens (Priority: P2)
+
+As a developer, I need predefined border radius values and shadow styles so that cards, buttons, and containers match the web app's visual depth and shape language.
+
+The web app defines:
+- **Border Radius**: none (0), sm (6pt), md (8pt), lg (12pt), xl (16pt), 2xl (24pt), 3xl (28pt), full (capsule)
+- **Shadows**: sm, md, lg, xl, 2xl with specific offset/blur/color values
+- **Glow Effects**: purple, pink, and cyan neon glow effects
+
+**Why this priority**: Shape and shadow create visual hierarchy and depth. They are important for cards and interactive elements.
+
+**Independent Test**: Can be fully tested by creating a shape/shadow demo screen that renders each variant and comparing with web screenshots.
+
+**Acceptance Scenarios**:
+
+1. **Given** the shape tokens are available, **When** a developer applies "2xl" border radius, **Then** corners render with 24pt radius
+2. **Given** the shadow tokens are available, **When** a developer applies the "lg" shadow, **Then** it renders with offset (0, 10), blur 15, and 10% black opacity spread
+3. **Given** the glow tokens are available, **When** a developer applies "glow-purple", **Then** it renders a 30pt blur purple glow matching #8b5cf6 at 50% opacity
+
+---
+
+### User Story 5 - Gradient Tokens (Priority: P3)
+
+As a developer, I need predefined gradient definitions so that backgrounds and accent elements match the web app's gradient styles.
+
+The web app defines:
+- **Primary Gradient**: 135deg, #8b5cf6 → #6d28d9 → #5b21b6
+- **Accent Gradient**: 135deg, #e879f9 → #d946ef → #c026d3
+- **Secondary Gradient**: 135deg, #22d3ee → #06b6d4 → #0891b2
+- **Neon Gradient**: 135deg, #8b5cf6 → #d946ef → #22d3ee
+- **Tech Gradient**: 135deg, #6d28d9 → #a21caf → #0891b2
+- **Background Gradient**: 135deg, #f5f3ff → #fdf4ff → #ecfeff
+
+**Why this priority**: Gradients are decorative accents used less frequently than solid colors, but they are important for brand identity on key screens.
+
+**Independent Test**: Can be fully tested by rendering each gradient on a sample view and comparing against web app gradient rendering.
+
+**Acceptance Scenarios**:
+
+1. **Given** the gradient tokens are available, **When** a developer applies the "neon" gradient, **Then** it renders a 135-degree linear gradient transitioning from purple (#8b5cf6) through pink (#d946ef) to cyan (#22d3ee)
+2. **Given** all six gradient tokens are available, **When** each is rendered, **Then** every gradient matches the web app's gradient direction, color stops, and positions
+
+---
+
+### User Story 6 - Component-Level Tokens (Priority: P3)
+
+As a developer, I need predefined component tokens (button, card, input field styles) so that common UI components are consistent with the web app without per-component manual configuration.
+
+The web app defines component tokens for:
+- **Buttons**: primary/secondary/outline variants with specific padding, radius (full), shadow, and gradient backgrounds
+- **Cards**: white background, 24pt radius, lg shadow, with small/medium/large padding variants
+- **Input Fields**: 12pt x 16pt padding, lg (12pt) radius, 2pt border, with default/focus/error border color states
+
+**Why this priority**: Component tokens build on primitive tokens (colors, spacing, shapes) and are less foundational. They can be composed from the primitive tokens.
+
+**Independent Test**: Can be fully tested by rendering sample button, card, and input field components and comparing against web app component screenshots.
+
+**Acceptance Scenarios**:
+
+1. **Given** the button component tokens are available, **When** a developer creates a primary button, **Then** it uses the primary gradient background, white text, full border radius, and medium shadow
+2. **Given** the card component tokens are available, **When** a developer creates a standard card, **Then** it uses white background, 24pt border radius, lg shadow, and 24pt padding
+3. **Given** the input field component tokens are available, **When** a developer creates a text field, **Then** it uses 12pt vertical / 16pt horizontal padding, 12pt border radius, 2pt border width, and neutral-200 default border color
+
+---
+
+### Edge Cases
+
+- What happens when the device is in Dark Mode? The current web design tokens are light-mode only. The iOS tokens should be structured to support future dark mode values without requiring a redesign of the token architecture.
+- What happens when Dynamic Type (accessibility font scaling) is enabled? Typography tokens should respect the user's accessibility settings while maintaining proportional relationships.
+- What happens if a color token is referenced that doesn't exist in the palette? The system should fail at compile time, not at runtime.
+- How are opacity values combined with colors? The web defines an opacity scale (0-100). The iOS tokens should provide a way to apply opacity to any color token.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The design token system MUST define all color palettes (primary, accent, secondary, neutral, semantic) with every shade matching the web app's hex values exactly
+- **FR-012**: The design token system MUST define four status colors — success (#22c55e), warning (#f59e0b), error (#ef4444), info (#3b82f6) — for use in validation feedback, alerts, banners, and toast messages
+- **FR-002**: The design token system MUST define typography presets (display, heading, body, caption, button, label, input) with font size, weight, line height, and letter spacing matching the web definitions
+- **FR-003**: The design token system MUST define a spacing scale with seven levels (xs through 3xl) matching the web spacing values
+- **FR-004**: The design token system MUST define border radius tokens with eight levels (none through full) matching the web shape values
+- **FR-005**: The design token system MUST define shadow tokens with five levels (sm through 2xl) and three glow effects (purple, pink, cyan) matching the web shadow definitions
+- **FR-006**: The design token system MUST define six gradient presets (primary, accent, secondary, neon, tech, background) matching the web gradient definitions
+- **FR-007**: The design token system MUST define component-level tokens for buttons (primary, secondary, outline), cards (standard with padding variants), and input fields (with state-based border colors)
+- **FR-008**: The design token system MUST be structured so that all values are resolved at compile time, preventing runtime errors from missing or mistyped token references
+- **FR-009**: The design token system MUST be compatible with Dynamic Type, allowing typography tokens to scale proportionally with the user's accessibility text size preference
+- **FR-010**: The design token system MUST be organized to support future addition of dark mode values without requiring restructuring of existing token definitions
+- **FR-011**: The design token system MUST provide an opacity scale (5% through 100% in the same increments as the web) that can be applied to any color token
+
+### Key Entities
+
+- **Color Palette**: A named group of color shades (e.g., "primary" with shades 50-900). Each shade has a name and an exact color value.
+- **Typography Preset**: A named combination of font family, size, weight, line height, and letter spacing (e.g., "heading-1" = SF Pro Display, 24pt, semibold, 1.2 line height).
+- **Spacing Token**: A named size value from a fixed scale used for padding, margins, and gaps (e.g., "md" = 16pt).
+- **Shape Token**: A named border radius value (e.g., "2xl" = 24pt) or shadow definition (e.g., "lg" = specific offset, blur, and opacity).
+- **Gradient Token**: A named linear gradient definition with direction and color stops (e.g., "neon" = 135deg from purple through pink to cyan).
+- **Component Token**: A named collection of primitive tokens that define the appearance of a specific component type (e.g., "primary button" = primary gradient + white text + full radius + md shadow).
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: 100% of color values in the iOS design token system match the corresponding web hex values exactly (verified by automated comparison)
+- **SC-002**: 100% of typography presets in the iOS system match the web definitions for font size, weight, line height, and letter spacing
+- **SC-003**: A developer can apply any design token to a view using a single, descriptive reference (e.g., one line of code per token application) without needing to know the underlying values
+- **SC-004**: All design tokens are validated at compile time — referencing a non-existent token produces a compile error, not a runtime failure
+- **SC-005**: Typography tokens respect Dynamic Type settings, scaling proportionally when the user changes their preferred text size
+- **SC-006**: The token architecture supports adding dark mode variants without modifying any existing token definitions or references in consuming views
+- **SC-007**: A new developer can find and apply any token within 30 seconds by browsing the token definitions, without consulting external documentation
+
+### Assumptions
+
+- The web app's `figma-design-tokens.json` and `DESIGN_SPEC.md` are the authoritative sources for all token values
+- The iOS app targets iOS 15+ and uses SwiftUI as the primary UI framework
+- SF Pro Display and SF Pro Text are the intended fonts, which are available natively on iOS (no custom font bundling required)
+- Pixel values from the web (px) map 1:1 to points (pt) on iOS
+- The initial implementation is light mode only; dark mode support means the architecture allows future extension, not that dark mode values are defined now
+- The opacity scale follows the same increments as the web: 0, 5, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100

--- a/specs/042-ios-design-tokens/tasks.md
+++ b/specs/042-ios-design-tokens/tasks.md
@@ -1,0 +1,306 @@
+# Tasks: iOS Design Tokens
+
+Implement a compile-time-safe SwiftUI design token system mirroring the web app's design language.
+
+## Table of Contents
+
+- [Phase 1: Setup](#phase-1-setup-shared-infrastructure)
+- [Phase 2: Foundational](#phase-2-foundational-blocking-prerequisites)
+- [Phase 3: User Story 1 — Brand Colors](#phase-3-user-story-1--brand-colors-priority-p1--mvp)
+- [Phase 4: User Story 2 — Typography](#phase-4-user-story-2--typography-priority-p1)
+- [Phase 5: User Story 3 — Spacing](#phase-5-user-story-3--spacing-priority-p2)
+- [Phase 6: User Story 4 — Shapes & Shadows](#phase-6-user-story-4--shapes--shadows-priority-p2)
+- [Phase 7: User Story 5 — Gradients](#phase-7-user-story-5--gradients-priority-p3)
+- [Phase 8: User Story 6 — Component Tokens](#phase-8-user-story-6--component-tokens-priority-p3)
+- [Phase 9: Polish](#phase-9-polish--cross-cutting-concerns)
+- [Dependencies & Execution Order](#dependencies--execution-order)
+- [Implementation Strategy](#implementation-strategy)
+
+---
+
+**Input**: Design documents from `/specs/042-ios-design-tokens/`
+**Prerequisites**: plan.md (required), spec.md (required), data-model.md, research.md, quickstart.md
+
+**Tests**: Tests are included — the spec requires XCTest unit tests to validate token values match web hex/pt values (SC-001, SC-002).
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing of each story.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2, US3)
+- Include exact file paths in descriptions
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Create the DesignSystem directory structure and shared utilities
+
+- [ ] T001 Create DesignSystem directory structure: `ios/AvaRobotics/DesignSystem/Tokens/`, `ios/AvaRobotics/DesignSystem/Components/`, `ios/AvaRobotics/DesignSystem/Extensions/`, and test directory `ios/AvaRoboticsTests/DesignSystem/`
+- [ ] T002 Implement Color hex initializer extension in `ios/AvaRobotics/DesignSystem/Extensions/Color+Hex.swift` — `Color.init(hex: String)` that parses 6-digit and 8-digit hex strings (with or without `#` prefix) into SwiftUI Color using sRGB color space
+- [ ] T003 Create View extension file with `.typography()` and `.tokenShadow()` convenience methods (stubs) in `ios/AvaRobotics/DesignSystem/Extensions/View+DesignSystem.swift`
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Opacity tokens are used by shadows and component tokens — must be available first
+
+**⚠️ CRITICAL**: OpacityToken is referenced by ShadowToken and Component styles
+
+- [ ] T004 Implement OpacityToken enum with static Double properties (opacity5 through opacity100 matching web scale: 0.05, 0.10, 0.20, 0.30, 0.40, 0.50, 0.60, 0.70, 0.80, 0.90, 1.00) in `ios/AvaRobotics/DesignSystem/Tokens/OpacityToken.swift`
+
+**Checkpoint**: Foundation ready — user story implementation can now begin
+
+---
+
+## Phase 3: User Story 1 — Brand Colors (Priority: P1) 🎯 MVP
+
+**Goal**: Define all color palettes (primary, accent, secondary, neutral, semantic, status) with every shade matching web hex values exactly
+
+**Independent Test**: Create unit tests that resolve each Color to UIColor, extract RGBA components, convert to hex string, and assert against spec values
+
+### Tests for User Story 1
+
+- [ ] T005 [P] [US1] Write ColorTokenTests in `ios/AvaRoboticsTests/DesignSystem/ColorTokenTests.swift` — test every color in Primary (10 shades: p50–p900), Accent (8 shades: a50–a700), Secondary (7 shades: s50–s600), Neutral (10 shades: n50–n900), Semantic (white, black), and Status (success, warning, error, info) by resolving `Color` → `UIColor` → RGBA → hex string and asserting against data-model.md hex values. Include a `hexString(from: Color) -> String` test helper.
+
+### Implementation for User Story 1
+
+- [ ] T006 [US1] Implement ColorToken enum with nested enums for each palette in `ios/AvaRobotics/DesignSystem/Tokens/ColorToken.swift`:
+  - `ColorToken.Primary` with static Color properties: p50 (#f5f3ff), p100 (#ede9fe), p200 (#ddd6fe), p300 (#c4b5fd), p400 (#a78bfa), p500 (#8b5cf6), p600 (#7c3aed), p700 (#6d28d9), p800 (#5b21b6), p900 (#4c1d95)
+  - `ColorToken.Accent` with static Color properties: a50 (#fdf4ff), a100 (#fae8ff), a200 (#f5d0fe), a300 (#f0abfc), a400 (#e879f9), a500 (#d946ef), a600 (#c026d3), a700 (#a21caf)
+  - `ColorToken.Secondary` with static Color properties: s50 (#ecfeff), s100 (#cffafe), s200 (#a5f3fc), s300 (#67e8f9), s400 (#22d3ee), s500 (#06b6d4), s600 (#0891b2)
+  - `ColorToken.Neutral` with static Color properties: n50 (#f8fafc), n100 (#f1f5f9), n200 (#e2e8f0), n300 (#cbd5e1), n400 (#94a3b8), n500 (#64748b), n600 (#475569), n700 (#334155), n800 (#1e293b), n900 (#0f172a)
+  - `ColorToken.Semantic` with static Color properties: white (#ffffff), black (#000000)
+  - `ColorToken.Status` with static Color properties: success (#22c55e), warning (#f59e0b), error (#ef4444), info (#3b82f6)
+  - All colors use `Color(hex:)` initializer from T002
+
+**Checkpoint**: Color tokens complete — all 41 color values match web spec, verified by unit tests
+
+---
+
+## Phase 4: User Story 2 — Typography (Priority: P1)
+
+**Goal**: Define 18 typography presets with font size, weight, line spacing, tracking, and Dynamic Type support via `@ScaledMetric`
+
+**Independent Test**: Unit test verifying each preset's size, weight mapping, lineSpacing, tracking, and relativeTo values
+
+### Tests for User Story 2
+
+- [ ] T007 [P] [US2] Write TypographyTokenTests in `ios/AvaRoboticsTests/DesignSystem/TypographyTokenTests.swift` — test all 18 presets (display1, display2, heading1–3, bodyLarge, bodyRegular, bodyMedium, bodySemibold, bodySmall, bodySmallMedium, caption, captionMedium, buttonLarge, buttonMedium, buttonSmall, label, input) verifying: size matches data-model.md pt value, weight matches specified weight, lineSpacing matches specified value, tracking matches specified value, relativeTo maps to correct Font.TextStyle. Also test that sizes are descending within categories (display > heading > body > caption).
+
+### Implementation for User Story 2
+
+- [ ] T008 [US2] Implement TypographyToken enum with cases for all 18 presets in `ios/AvaRobotics/DesignSystem/Tokens/TypographyToken.swift`:
+  - Enum cases: display1, display2, heading1, heading2, heading3, bodyLarge, bodyRegular, bodyMedium, bodySemibold, bodySmall, bodySmallMedium, caption, captionMedium, buttonLarge, buttonMedium, buttonSmall, label, input
+  - Computed properties: `size` (CGFloat), `weight` (Font.Weight), `lineSpacing` (CGFloat), `tracking` (CGFloat), `relativeTo` (Font.TextStyle) — values per data-model.md typography table
+  - Computed `font` property returning `Font.system(size:weight:design:)` with `.default` design
+- [ ] T009 [US2] Implement TypographyModifier ViewModifier in `ios/AvaRobotics/DesignSystem/Tokens/TypographyToken.swift` (same file, below the enum):
+  - Uses `@ScaledMetric(wrappedValue:relativeTo:)` initialized from `token.size` and `token.relativeTo`
+  - Applies `.font(.system(size: scaledSize, weight: token.weight, design: .default))`, `.lineSpacing(token.lineSpacing)`, `.tracking(token.tracking)`
+- [ ] T010 [US2] Update View+DesignSystem extension in `ios/AvaRobotics/DesignSystem/Extensions/View+DesignSystem.swift` — replace `.typography()` stub with real implementation: `func typography(_ token: TypographyToken) -> some View` that applies `TypographyModifier(token)`
+
+**Checkpoint**: Typography tokens complete — all 18 presets match web spec, Dynamic Type scales proportionally
+
+---
+
+## Phase 5: User Story 3 — Spacing (Priority: P2)
+
+**Goal**: Define 7-level spacing scale (xs through xxxl) matching web values
+
+**Independent Test**: Unit test asserting each spacing token's CGFloat value
+
+### Tests for User Story 3
+
+- [ ] T011 [P] [US3] Write SpacingTokenTests in `ios/AvaRoboticsTests/DesignSystem/SpacingTokenTests.swift` — test all 7 values: xs==4, sm==8, md==16, lg==24, xl==32, xxl==48, xxxl==64. Also test monotonically increasing order.
+
+### Implementation for User Story 3
+
+- [ ] T012 [US3] Implement SpacingToken enum with static CGFloat properties in `ios/AvaRobotics/DesignSystem/Tokens/SpacingToken.swift`: xs=4, sm=8, md=16, lg=24, xl=32, xxl=48, xxxl=64
+
+**Checkpoint**: Spacing tokens complete — all 7 values match web spec
+
+---
+
+## Phase 6: User Story 4 — Shapes & Shadows (Priority: P2)
+
+**Goal**: Define border radius tokens (8 levels), border width tokens (2 levels), shadow tokens (5 standard + 3 glow effects)
+
+**Independent Test**: Unit tests asserting corner radius values, border width values, shadow radius/offset/color configurations
+
+### Tests for User Story 4
+
+- [ ] T013 [P] [US4] Write ShapeTokenTests in `ios/AvaRoboticsTests/DesignSystem/ShapeTokenTests.swift` — test CornerRadius values: none==0, sm==6, md==8, lg==12, xl==16, xxl==24, xxxl==28, full==9999. Test BorderWidth values: thin==1, regular==2. Test monotonically increasing for corner radius scale.
+- [ ] T014 [P] [US4] Write ShadowTokenTests in `ios/AvaRoboticsTests/DesignSystem/ShadowTokenTests.swift` — test all 5 standard shadows (sm, md, lg, xl, xxl) for correct x, y, blur radius, and color opacity values per data-model.md. Test all 3 glow effects (glowPurple, glowPink, glowCyan) for blur==30, x==0, y==0, and correct color/opacity. Test shadow radius is monotonically increasing across sm→md→lg→xl→xxl.
+
+### Implementation for User Story 4
+
+- [ ] T015 [P] [US4] Implement ShapeToken enum with nested enums in `ios/AvaRobotics/DesignSystem/Tokens/ShapeToken.swift`:
+  - `ShapeToken.CornerRadius` with static CGFloat properties: none=0, sm=6, md=8, lg=12, xl=16, xxl=24, xxxl=28, full=9999
+  - `ShapeToken.BorderWidth` with static CGFloat properties: thin=1, regular=2
+- [ ] T016 [US4] Implement ShadowToken enum with cases and computed properties in `ios/AvaRobotics/DesignSystem/Tokens/ShadowToken.swift`:
+  - Cases: sm, md, lg, xl, xxl, glowPurple, glowPink, glowCyan
+  - Computed properties: `radius` (CGFloat), `x` (CGFloat), `y` (CGFloat), `color` (Color) — values per data-model.md shadow tables
+  - Implement ShadowModifier ViewModifier that applies `content.shadow(color:radius:x:y:)`
+- [ ] T017 [US4] Update View+DesignSystem extension in `ios/AvaRobotics/DesignSystem/Extensions/View+DesignSystem.swift` — replace `.tokenShadow()` stub with real implementation: `func tokenShadow(_ token: ShadowToken) -> some View` that applies `ShadowModifier(token:)`
+
+**Checkpoint**: Shape and shadow tokens complete — all border radii, shadows, and glow effects match web spec
+
+---
+
+## Phase 7: User Story 5 — Gradients (Priority: P3)
+
+**Goal**: Define 6 gradient presets as LinearGradient values matching web gradient definitions
+
+**Independent Test**: Unit tests verifying gradient color stops match spec hex values
+
+### Tests for User Story 5
+
+- [ ] T018 [P] [US5] Write GradientTokenTests in `ios/AvaRoboticsTests/DesignSystem/GradientTokenTests.swift` — test all 6 gradients (primary, accent, secondary, neon, tech, background) by verifying the `stops` property returns 3 Color values matching the data-model.md hex values for each gradient. Use the same `hexString(from:)` helper pattern as ColorTokenTests.
+
+### Implementation for User Story 5
+
+- [ ] T019 [US5] Implement GradientToken enum with static LinearGradient properties in `ios/AvaRobotics/DesignSystem/Tokens/GradientToken.swift`:
+  - Static properties: primary, accent, secondary, neon, tech, background
+  - Each returns a `LinearGradient` with `startPoint: .topLeading, endPoint: .bottomTrailing` and 3 color stops per data-model.md gradient table
+  - Also expose a `stops` computed property returning `[Color]` for testability
+  - Color stops reference `ColorToken` values where possible, or use `Color(hex:)` for stops not in the palette
+
+**Checkpoint**: Gradient tokens complete — all 6 gradients match web spec direction and color stops
+
+---
+
+## Phase 8: User Story 6 — Component Tokens (Priority: P3)
+
+**Goal**: Implement button styles (primary, secondary, outline), card modifier, and text field style composing primitive tokens
+
+**Independent Test**: Verify component styles compile and compose correct primitive token references
+
+**Prerequisites**: Requires US1 (colors), US2 (typography), US3 (spacing), US4 (shapes/shadows), US5 (gradients)
+
+### Implementation for User Story 6
+
+- [ ] T020 [US6] Implement ButtonStyles in `ios/AvaRobotics/DesignSystem/Components/ButtonStyles.swift`:
+  - `BrandPrimaryButtonStyle: ButtonStyle` — primary gradient background, white text, buttonMedium typography, full corner radius, md shadow, lg horizontal / md vertical padding. Pressed state reduces opacity to 0.8.
+  - `BrandSecondaryButtonStyle: ButtonStyle` — accent gradient background, same text/radius/shadow/padding as primary
+  - `BrandOutlineButtonStyle: ButtonStyle` — transparent background, 2pt primary-500 border, primary-500 text, buttonMedium typography, full corner radius, lg horizontal / md vertical padding. Pressed state reduces opacity to 0.6.
+  - Convenience extensions on `ButtonStyle`: `static var brandPrimary`, `static var brandSecondary`, `static var brandOutline`
+- [ ] T021 [P] [US6] Implement CardModifier in `ios/AvaRobotics/DesignSystem/Components/CardModifier.swift`:
+  - `CardPadding` enum with cases: small (SpacingToken.md), medium (SpacingToken.lg), large (SpacingToken.xl)
+  - `CardModifier: ViewModifier` — white background, xxl corner radius (24pt), lg shadow, configurable padding (default: medium)
+  - View extension: `func cardStyle(padding: CardPadding = .medium) -> some View`
+- [ ] T022 [P] [US6] Implement BrandedTextFieldStyle in `ios/AvaRobotics/DesignSystem/Components/TextFieldStyles.swift`:
+  - `BrandedTextFieldStyle: TextFieldStyle` — input typography, 12pt vertical / md horizontal padding, lg corner radius (12pt), regular border width (2pt), neutral-200 default border, primary-500 focus border (using `@FocusState`), error state support via environment or parameter
+  - Convenience extension: `static var branded`
+
+**Checkpoint**: Component tokens complete — buttons, cards, and text fields compose primitive tokens correctly
+
+---
+
+## Phase 9: Polish & Cross-Cutting Concerns
+
+**Purpose**: Verify cross-story integration, compile-time safety, and documentation
+
+- [ ] T023 Verify compile-time safety by attempting to reference a non-existent token (e.g., `ColorToken.Primary.p999`) and confirming it produces a compile error — document verification in a comment on the implementation issue
+- [ ] T024 Verify Dynamic Type support by changing the iOS Simulator's text size setting (Settings → Accessibility → Display & Text Size → Larger Text) and confirming typography tokens scale proportionally — document verification in a comment on the implementation issue
+- [ ] T025 Run all unit tests (ColorTokenTests, TypographyTokenTests, SpacingTokenTests, ShapeTokenTests, ShadowTokenTests, GradientTokenTests) and confirm 100% pass rate — document test results in a comment on the implementation issue
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies — can start immediately
+- **Foundational (Phase 2)**: Depends on Setup (T001–T003) completion
+- **US1 Colors (Phase 3)**: Depends on Phase 1 (needs Color+Hex.swift from T002)
+- **US2 Typography (Phase 4)**: Depends on Phase 1 (needs View+DesignSystem.swift from T003)
+- **US3 Spacing (Phase 5)**: Depends on Phase 1 only
+- **US4 Shapes & Shadows (Phase 6)**: Depends on Phase 1 (needs View+DesignSystem.swift from T003) and Phase 2 (OpacityToken for shadow colors)
+- **US5 Gradients (Phase 7)**: Depends on Phase 3 (references ColorToken values)
+- **US6 Components (Phase 8)**: Depends on US1, US2, US3, US4, US5 (composes all primitive tokens)
+- **Polish (Phase 9)**: Depends on all user stories being complete
+
+### User Story Dependencies
+
+```text
+Phase 1 (Setup)
+    ↓
+Phase 2 (Foundational: OpacityToken)
+    ↓
+┌───────────────────────────────────────────┐
+│  US1 (Colors) ──→ US5 (Gradients)        │  US2 (Typography)
+│                                           │
+│  US3 (Spacing)   US4 (Shapes & Shadows)  │
+└───────────────────────────────────────────┘
+         ↓              ↓              ↓
+         └──── US6 (Components) ──────┘
+                        ↓
+                  Phase 9 (Polish)
+```
+
+- US1, US2, US3 can run in **parallel** after Phase 2
+- US4 can run in **parallel** with US1, US2, US3 (after Phase 2)
+- US5 depends on US1 (color references)
+- US6 depends on all other user stories (US1–US5)
+
+### Parallel Opportunities
+
+Within each story, test tasks marked [P] can run in parallel with each other. Implementation tasks within different stories can run in parallel when they have no dependency.
+
+**Maximum parallelism** (after Phase 2):
+- Stream A: US1 (Colors) → US5 (Gradients)
+- Stream B: US2 (Typography)
+- Stream C: US3 (Spacing) + US4 (Shapes & Shadows)
+- Then: US6 (Components) after all streams complete
+
+---
+
+## Parallel Example: After Phase 2
+
+```text
+# These can all start simultaneously:
+Stream A: T005 (ColorTokenTests) + T006 (ColorToken.swift)
+Stream B: T007 (TypographyTokenTests) + T008-T010 (TypographyToken)
+Stream C: T011 (SpacingTokenTests) + T012 (SpacingToken.swift)
+Stream D: T013-T014 (Shape/ShadowTests) + T015-T017 (Shape/Shadow impl)
+
+# After Stream A completes:
+Stream A continues: T018 (GradientTokenTests) + T019 (GradientToken.swift)
+
+# After all streams complete:
+T020-T022 (Component tokens)
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1: Setup (T001–T003)
+2. Complete Phase 2: Foundational (T004)
+3. Complete Phase 3: User Story 1 — Colors (T005–T006)
+4. **STOP and VALIDATE**: Run ColorTokenTests, verify all 41 colors match web hex values
+5. Deploy/demo: developers can start using `ColorToken.Primary.p500` etc.
+
+### Incremental Delivery
+
+1. Setup + Foundational → Foundation ready
+2. Add US1 (Colors) → Test → **MVP!** Developers have color tokens
+3. Add US2 (Typography) → Test → Developers have `.typography()` modifier
+4. Add US3 (Spacing) + US4 (Shapes) → Test → Full layout token set
+5. Add US5 (Gradients) → Test → Gradient backgrounds available
+6. Add US6 (Components) → Test → `.buttonStyle(.brandPrimary)`, `.cardStyle()` available
+7. Polish → Full validation and documentation
+
+---
+
+## Notes
+
+- [P] tasks = different files, no dependencies
+- [Story] label maps task to specific user story for traceability
+- Each user story should be independently completable and testable
+- Commit after each task or logical group
+- Stop at any checkpoint to validate story independently
+- All color hex values come from `figma-design-tokens.json` / `DESIGN_SPEC.md` (authoritative sources)
+- px values from web map 1:1 to pt values on iOS


### PR DESCRIPTION
## Summary
- Implement a compile-time-safe SwiftUI design token system with enum-based tokens mirroring the web app's Figma design language
- Add 7 token categories: colors (41 shades), typography (18 presets with Dynamic Type via `@ScaledMetric`), spacing (7 levels), shapes (8 corner radii + 2 border widths), shadows (5 standard + 3 glow effects), gradients (6 presets), and opacity (11 levels)
- Add 3 component styles: button styles (primary/secondary/outline), card modifier, and branded text field style with focus/error states
- Include XCTest unit tests validating all token values against the web spec hex/pt values
- Add spec, plan, research, data-model, quickstart, and tasks documentation

## Test plan
- [ ] Verify all 6 test files compile and pass (ColorTokenTests, TypographyTokenTests, SpacingTokenTests, ShapeTokenTests, ShadowTokenTests, GradientTokenTests)
- [ ] Verify `ColorToken.Primary.p999` produces a compile error (compile-time safety)
- [ ] Verify typography tokens scale with Dynamic Type in iOS Simulator (Settings → Accessibility → Larger Text)
- [ ] Confirm all 41 color hex values match `figma-design-tokens.json` / `DESIGN_SPEC.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)